### PR TITLE
fix: remove broken types-all dependency from mypy pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,6 @@ repos:
     rev: v1.8.0
     hooks:
       - id: mypy
-        additional_dependencies: [types-all]
         args: [--ignore-missing-imports]
 
   - repo: https://github.com/PyCQA/bandit


### PR DESCRIPTION
## 问题

GitHub Actions CI 在 `Run pre-commit hooks` 步骤失败，错误信息：
```
ERROR: Could not find a version that satisfies the requirement types-pkg-resources (from types-all) (from versions: none)
ERROR: No matching distribution found for types-pkg-resources
```

## 根本原因

`types-all` 是一个元包，尝试安装数百个类型存根，包括已不存在的 `types-pkg-resources` 包。

## 解决方案

从 mypy pre-commit hook 的 `additional_dependencies` 中移除 `types-all`。

这是安全的，因为：
1. 项目已经使用 `--ignore-missing-imports` 标志
2. 项目的主要依赖（pygls, lsprotocol）不需要类型存根
3. 这将使 CI 更快（不需要安装数百个不必要的包）

## 测试

此修复将解决 CI 预提交挂钩安装失败的问题。

Fixes CI failures in recent commits.