### PR TITLE
fix: stop masking CI test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
@@ -30,7 +29,7 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest tests/ -v --cov=src --cov-report=xml || echo "Tests need dependency update"
+        pytest tests/ -v --cov=src --cov-report=xml
 
     - name: Upload coverage
       uses: codecov/codecov-action@v4


### PR DESCRIPTION
## Summary
- remove the job-level `continue-on-error` setting from CI
- let the pytest step fail normally instead of replacing failures with an echo

## Verification
- `python3.12` temporary virtualenv outside the repo
- `pip install -e ".[dev]"`
- `pytest tests/ -v --cov=src --cov-report=xml` -> 338 passed

Closes #17
