### PR TITLE
chore: finish metadata, CI, version, and validation maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,37 +2,69 @@ name: CI
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [main]
   pull_request:
-    branches: [ main, master ]
+    branches: [main]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pytest pytest-cov
-        pip install -e ".[dev]" || pip install -e .
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
 
-    - name: Run tests
-      run: |
-        pytest tests/ -v --cov=src --cov-report=xml
+      - name: Run tests with coverage
+        run: pytest tests/ -v --cov=orca_lsp --cov-report=term-missing --cov-report=xml
 
-    - name: Upload coverage
-      uses: codecov/codecov-action@v4
-      with:
-        files: ./coverage.xml
-        fail_ci_if_error: false
+      - name: Upload coverage
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+
+  quality:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Check formatting
+        run: |
+          black --check src tests/test_chemistry_validation.py tests/test_metadata.py
+          isort --check-only src tests/test_chemistry_validation.py tests/test_metadata.py
+
+      - name: Lint
+        run: |
+          flake8 src tests/test_chemistry_validation.py tests/test_metadata.py \
+            --max-line-length=100 \
+            --extend-ignore=E501
+
+      - name: Type check
+        run: mypy src

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 NewtonTech
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,34 @@ name = "orca-lsp"
 version = "0.5.4"
 description = "Language Server Protocol for ORCA quantum chemistry software"
 readme = "README.md"
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
+authors = [
+    {name = "NewtonTech"},
+]
+keywords = ["orca", "lsp", "language-server", "quantum-chemistry"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Chemistry",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
 requires-python = ">=3.9"
 dependencies = [
     "pygls>=1.2.0,<2.0.0",
     "lsprotocol>=2023.0.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/newtontech/orca-lsp"
+Issues = "https://github.com/newtontech/orca-lsp/issues"
+Repository = "https://github.com/newtontech/orca-lsp"
 
 [project.optional-dependencies]
 dev = [

--- a/src/orca_lsp/__init__.py
+++ b/src/orca_lsp/__init__.py
@@ -1,3 +1,8 @@
 """orca-lsp - Language Server Protocol for ORCA"""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("orca-lsp")
+except PackageNotFoundError:  # pragma: no cover - only used from an unpackaged source tree
+    __version__ = "0.5.4"

--- a/src/orca_lsp/parser.py
+++ b/src/orca_lsp/parser.py
@@ -2,8 +2,9 @@
 
 import re
 from dataclasses import dataclass, field
-from typing import List, Dict, Optional, Tuple, Any
-from .keywords import DFT_FUNCTIONALS, WAVEFUNCTION_METHODS, BASIS_SETS, JOB_TYPES, ELEMENTS
+from typing import Any, Dict, List, Optional, Tuple
+
+from .keywords import BASIS_SETS, DFT_FUNCTIONALS, ELEMENTS, JOB_TYPES, WAVEFUNCTION_METHODS
 
 
 @dataclass
@@ -88,6 +89,12 @@ class ORCAParser:
         self.basis_sets = set(BASIS_SETS.keys())
         self.job_types = set(JOB_TYPES.keys())
         self.all_methods = self.dft_functionals | self.wavefunction_methods
+        self._dft_functionals_by_upper = {name.upper(): name for name in self.dft_functionals}
+        self._wavefunction_methods_by_upper = {
+            name.upper(): name for name in self.wavefunction_methods
+        }
+        self._basis_sets_by_upper = {name.upper(): name for name in self.basis_sets}
+        self._job_types_by_upper = {name.upper(): name for name in self.job_types}
 
     def parse(self, content: str) -> ParseResult:
         """Parse complete ORCA input file"""
@@ -144,29 +151,16 @@ class ORCAParser:
         for token in tokens:
             token_upper = token.upper()
 
-            if token_upper in self.dft_functionals:
-                result.methods.append(token)
-            elif token_upper in self.wavefunction_methods:
-                result.methods.append(token)
-            elif token_upper in self.basis_sets:
-                result.basis_sets.append(token)
-            elif token_upper in self.job_types:
-                result.job_types.append(token)
+            if token_upper in self._dft_functionals_by_upper:
+                result.methods.append(self._dft_functionals_by_upper[token_upper])
+            elif token_upper in self._wavefunction_methods_by_upper:
+                result.methods.append(self._wavefunction_methods_by_upper[token_upper])
+            elif token_upper in self._basis_sets_by_upper:
+                result.basis_sets.append(self._basis_sets_by_upper[token_upper])
+            elif token_upper in self._job_types_by_upper:
+                result.job_types.append(self._job_types_by_upper[token_upper])
             else:
-                # Check case-insensitively for some keywords
-                if token_upper in [k.upper() for k in self.all_methods]:
-                    # Find the correct case version
-                    for method in self.all_methods:  # pragma: no branch (always breaks)
-                        if method.upper() == token_upper:
-                            result.methods.append(method)
-                            break
-                elif token_upper in [k.upper() for k in self.basis_sets]:
-                    for basis in self.basis_sets:  # pragma: no branch (always breaks)
-                        if basis.upper() == token_upper:
-                            result.basis_sets.append(basis)
-                            break
-                else:
-                    result.other_keywords.append(token)
+                result.other_keywords.append(token)
 
         return result
 
@@ -434,10 +428,10 @@ class ORCAParser:
         if not result.simple_input:
             return
 
-        methods = [m.upper() for m in result.simple_input.methods]
+        keywords = self._simple_input_keywords(result.simple_input)
 
         scf_types = {"RHF", "UHF", "ROHF"}
-        found_scf = [m for m in methods if m in scf_types]
+        found_scf = [keyword for keyword in keywords if keyword in scf_types]
         if len(found_scf) > 1:
             result.errors.append(
                 {
@@ -452,9 +446,14 @@ class ORCAParser:
         if not result.simple_input:
             return
 
-        methods = [m.upper() for m in result.simple_input.methods]
+        keywords = self._simple_input_keywords(result.simple_input)
+        methods = {method.upper() for method in result.simple_input.methods}
 
-        has_dft = any(m in {"B3LYP", "PBE0", "PBE", "M06", "TPSS", "HF", "RHF", "UHF"} for m in methods)
+        self._check_mutually_exclusive_groups(result, keywords)
+
+        has_dft = any(
+            m in {"B3LYP", "PBE0", "PBE", "M06", "TPSS", "HF", "RHF", "UHF"} for m in methods
+        )
         has_mp2 = "MP2" in methods or "RI-MP2" in methods
 
         if has_dft and has_mp2:
@@ -465,6 +464,51 @@ class ORCAParser:
                     "severity": "warning",
                 }
             )
+
+    def _simple_input_keywords(self, simple_input: SimpleInput) -> List[str]:
+        """Return all simple-line keywords normalized for validation."""
+        tokens = (
+            simple_input.methods
+            + simple_input.basis_sets
+            + simple_input.job_types
+            + simple_input.other_keywords
+        )
+        return [token.upper() for token in tokens]
+
+    def _check_mutually_exclusive_groups(self, result: ParseResult, keywords: List[str]) -> None:
+        """Check simple-line keyword groups where ORCA accepts only one choice."""
+        if not result.simple_input:
+            return
+
+        keyword_set = set(keywords)
+        functional_keywords = {
+            keyword.upper()
+            for keyword in result.simple_input.methods
+            if keyword.upper() in self._dft_functionals_by_upper
+        }
+        basis_keywords = {basis.upper() for basis in result.simple_input.basis_sets}
+
+        exclusive_groups = [
+            ("dispersion corrections", {"D3", "D3BJ", "D4"}),
+            ("RI approximations", {"RIJCOSX", "RI-J"}),
+            ("DFT functionals", functional_keywords),
+            ("correlation methods", {"MP2", "RI-MP2", "SCS-MP2", "CCSD", "CCSD(T)"}),
+            ("basis sets", basis_keywords),
+            ("SCF convergence settings", {"TIGHTSCF", "LOOSESCF"}),
+            ("relativistic corrections", {"ZORA", "DKH"}),
+            ("solvent models", {"CPCM", "SMD"}),
+        ]
+
+        for label, group in exclusive_groups:
+            found = sorted(keyword_set & group)
+            if len(found) > 1:
+                result.errors.append(
+                    {
+                        "message": f"Mutually exclusive {label}: {' '.join(found)}",
+                        "line": result.simple_input.line_number,
+                        "severity": "error",
+                    }
+                )
 
     def _check_spin_charge(self, result: ParseResult) -> None:
         """Check spin/charge consistency in geometry"""

--- a/src/orca_lsp/server.py
+++ b/src/orca_lsp/server.py
@@ -3,8 +3,10 @@
 import re
 from typing import TYPE_CHECKING, List, Optional
 
-from pygls.server import LanguageServer
 from lsprotocol.types import (
+    CodeAction,
+    CodeActionKind,
+    CodeActionParams,
     CompletionItem,
     CompletionItemKind,
     CompletionList,
@@ -20,31 +22,30 @@ from lsprotocol.types import (
     Position,
     Range,
     TextEdit,
-    CodeAction,
-    CodeActionKind,
-    CodeActionParams,
     WorkspaceEdit,
 )
+from pygls.server import LanguageServer
 
 if TYPE_CHECKING:
     from pygls.workspace import TextDocument
 
-from .parser import ORCAParser
+from . import __version__
 from .keywords import (
-    DFT_FUNCTIONALS,
-    WAVEFUNCTION_METHODS,
     BASIS_SETS,
+    DFT_FUNCTIONALS,
+    ELEMENTS,
     JOB_TYPES,
     PERCENT_BLOCKS,
-    ELEMENTS,
+    WAVEFUNCTION_METHODS,
 )
+from .parser import ORCAParser
 
 
 class ORCALanguageServer(LanguageServer):
     """ORCA Language Server"""
 
     def __init__(self) -> None:
-        super().__init__("orca-lsp", "0.5.4")
+        super().__init__("orca-lsp", __version__)
         self.parser = ORCAParser()
         self._setup_features()
 

--- a/tests/test_chemistry_validation.py
+++ b/tests/test_chemistry_validation.py
@@ -1,0 +1,39 @@
+"""Tests for chemistry keyword validation."""
+
+import pytest
+
+from orca_lsp.parser import ORCAParser
+
+
+def parse_messages(content: str) -> list[str]:
+    """Parse content and return diagnostic messages."""
+    result = ORCAParser().parse(content)
+    return [item["message"] for item in result.errors + result.warnings]
+
+
+@pytest.mark.parametrize(
+    ("simple_line", "expected_message"),
+    [
+        ("! B3LYP def2-SVP D3 D4", "Mutually exclusive dispersion corrections"),
+        ("! B3LYP def2-SVP RIJCOSX RI-J", "Mutually exclusive RI approximations"),
+        ("! BP86 B3LYP def2-SVP", "Mutually exclusive DFT functionals"),
+        ("! MP2 CCSD(T) def2-SVP", "Mutually exclusive correlation methods"),
+        ("! B3LYP def2-SVP def2-TZVP", "Mutually exclusive basis sets"),
+        ("! B3LYP def2-SVP TightSCF LooseSCF", "Mutually exclusive SCF convergence"),
+        ("! B3LYP def2-SVP ZORA DKH", "Mutually exclusive relativistic corrections"),
+        ("! B3LYP def2-SVP CPCM SMD", "Mutually exclusive solvent models"),
+    ],
+)
+def test_mutually_exclusive_keywords(simple_line: str, expected_message: str):
+    """Mutually exclusive simple-line keywords should be reported as errors."""
+    content = f"{simple_line}\n%maxcore 2000\n* xyz 0 1\nH 0 0 0\n*"
+    messages = parse_messages(content)
+
+    assert any(expected_message in message for message in messages)
+
+
+def test_hybrid_functional_with_mp2_warns():
+    """Hybrid DFT plus MP2 should suggest a double-hybrid functional."""
+    messages = parse_messages("! B3LYP MP2 def2-SVP\n%maxcore 2000\n* xyz 0 1\nH 0 0 0\n*")
+
+    assert any("double-hybrid" in message for message in messages)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,18 @@
+"""Tests for package metadata."""
+
+from importlib.metadata import version
+from pathlib import Path
+
+from orca_lsp import __version__
+
+
+def test_runtime_version_matches_installed_metadata():
+    """Runtime package version should match project metadata."""
+    assert __version__ == version("orca-lsp")
+
+
+def test_license_file_present():
+    """Repository should ship the declared MIT license text."""
+    license_text = Path("LICENSE").read_text(encoding="utf-8")
+    assert "MIT License" in license_text
+    assert "NewtonTech" in license_text


### PR DESCRIPTION
## Summary
- add MIT LICENSE plus package metadata fields and project URLs
- expand CI to a Python 3.9-3.12 test matrix with coverage upload and a quality job for formatting, lint, and mypy
- derive runtime/server version from installed package metadata to prevent drift
- add focused simple-line validation for mutually exclusive ORCA keyword groups and invalid method combinations
- replace repeated case-insensitive parser list scans with precomputed lookup maps

## Validation
- `.venv/bin/pytest -q` -> 355 passed, 1 existing collection warning
- `.venv/bin/pytest tests/ -v --cov=orca_lsp --cov-report=term-missing --cov-report=xml` -> 355 passed, 99% coverage, 1 existing collection warning
- `.venv/bin/black --check src tests/test_chemistry_validation.py tests/test_metadata.py` -> passed
- `.venv/bin/isort --check-only src tests/test_chemistry_validation.py tests/test_metadata.py` -> passed
- `.venv/bin/flake8 src tests/test_chemistry_validation.py tests/test_metadata.py --max-line-length=100 --extend-ignore=E501` -> passed
- `.venv/bin/mypy src` -> passed with existing mypy 2.x warning about `python_version = 3.9`
- `.venv/bin/python -m pip check` -> no broken requirements

Closes #2
Closes #3
Closes #5
Closes #20

## Related follow-up
- #18 remains open: consolidating coverage-chasing tests is broad test-suite cleanup, not a compact maintenance fix.
- #19 remains open: robust ORCA tokenization/block parsing needs parser design work and behavior tests beyond this validation patch.
- #13 is partially touched only by the parser case-insensitive lookup optimization; the remaining server sorting/regex/completion optimizations should stay in a dedicated performance PR.
- #14, #15, and #16 remain open: their DRY/SOLID items call for larger refactors across parser/server/test architecture.
- Existing PR #4 is superseded by this PR because it only adds LICENSE and had stale failed/cancelled checks.