### PR TITLE
refactor: address SOLID principle violations in server and parser

### DIFF
--- a/src/orca_lsp/parser.py
+++ b/src/orca_lsp/parser.py
@@ -6,6 +6,12 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from .keywords import BASIS_SETS, DFT_FUNCTIONALS, ELEMENTS, JOB_TYPES, WAVEFUNCTION_METHODS
 
+# Pre-compiled regex patterns for performance (avoid recompilation on every loop)
+_NPROCS_RE = re.compile(r"nprocs\s+(\d+)", re.IGNORECASE)
+_MAXITER_RE = re.compile(r"maxiter\s+(\d+)", re.IGNORECASE)
+_GTENSOR_RE = re.compile(r"gtensor\s+(\d+)", re.IGNORECASE)
+_NROOTS_RE = re.compile(r"nroots\s+(\d+)", re.IGNORECASE)
+
 
 @dataclass
 class SimpleInput:
@@ -244,7 +250,7 @@ class ORCAParser:
             # %pal nprocs 4 end
             for line in lines:
                 if "nprocs" in line.lower():
-                    match = re.search(r"nprocs\s+(\d+)", line, re.IGNORECASE)
+                    match = _NPROCS_RE.search(line)
                     if match:
                         block.parameters["nprocs"] = int(match.group(1))
 
@@ -264,7 +270,7 @@ class ORCAParser:
             for line in lines:
                 stripped = line.strip().lower()
                 if "maxiter" in stripped:
-                    match = re.search(r"maxiter\s+(\d+)", stripped)
+                    match = _MAXITER_RE.search(stripped)
                     if match:
                         block.parameters["maxiter"] = int(match.group(1))
 
@@ -273,7 +279,7 @@ class ORCAParser:
             for line in lines:
                 stripped = line.strip().lower()
                 if "gtensor" in stripped:
-                    match = re.search(r"gtensor\s+(\d+)", stripped)
+                    match = _GTENSOR_RE.search(stripped)
                     if match:
                         block.parameters["gtensor"] = int(match.group(1))
 
@@ -282,7 +288,7 @@ class ORCAParser:
             for line in lines:
                 stripped = line.strip().lower()
                 if "nroots" in stripped:
-                    match = re.search(r"nroots\s+(\d+)", stripped)
+                    match = _NROOTS_RE.search(stripped)
                     if match:
                         block.parameters["nroots"] = int(match.group(1))
 

--- a/src/orca_lsp/parser.py
+++ b/src/orca_lsp/parser.py
@@ -2,7 +2,7 @@
 
 import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from .keywords import BASIS_SETS, DFT_FUNCTIONALS, ELEMENTS, JOB_TYPES, WAVEFUNCTION_METHODS
 
@@ -101,6 +101,16 @@ class ORCAParser:
         }
         self._basis_sets_by_upper = {name.upper(): name for name in self.basis_sets}
         self._job_types_by_upper = {name.upper(): name for name in self.job_types}
+
+        # Registry mapping block names to parameter handlers (OCP: extensible without modification)
+        self._block_handlers: Dict[str, Callable[[PercentBlock, str], None]] = {
+            "maxcore": self._parse_maxcore,
+            "method": self._parse_method,
+            "pal": self._parse_pal,
+            "scf": self._parse_scf,
+            "eprnmr": self._parse_eprnmr,
+            "rirpa": self._parse_rirpa,
+        }
 
     def parse(self, content: str) -> ParseResult:
         """Parse complete ORCA input file"""
@@ -233,64 +243,64 @@ class ORCAParser:
         return block, block.line_end
 
     def _parse_block_parameters(self, block: PercentBlock, content: str) -> None:
-        """Parse parameters for a % block"""
-        lines = content.split("\n")
+        """Parse parameters for a % block using a handler registry."""
+        handler = self._block_handlers.get(block.name)
+        if handler is not None:
+            handler(block, content)
 
-        if block.name == "maxcore":
-            # %maxcore 4000
-            for line in lines:
-                parts = line.split()
-                if len(parts) >= 2 and parts[0].lower() == "%maxcore":
-                    try:
-                        block.parameters["memory"] = int(parts[1])
-                    except ValueError:
-                        pass
+    @staticmethod
+    def _parse_regex_param(
+        block: PercentBlock,
+        content: str,
+        keyword: str,
+        pattern: "re.Pattern[str]",
+        param_name: str,
+    ) -> None:
+        """Extract an integer parameter matching a regex pattern."""
+        for line in content.split("\n"):
+            if keyword in line.lower():
+                match = pattern.search(line)
+                if match:
+                    block.parameters[param_name] = int(match.group(1))
 
-        elif block.name == "pal":
-            # %pal nprocs 4 end
-            for line in lines:
-                if "nprocs" in line.lower():
-                    match = _NPROCS_RE.search(line)
-                    if match:
-                        block.parameters["nprocs"] = int(match.group(1))
+    @staticmethod
+    def _parse_maxcore(block: PercentBlock, content: str) -> None:
+        """Parse %maxcore block parameters."""
+        for line in content.split("\n"):
+            parts = line.split()
+            if len(parts) >= 2 and parts[0].lower() == "%maxcore":
+                try:
+                    block.parameters["memory"] = int(parts[1])
+                except ValueError:
+                    pass
 
-        elif block.name == "method":
-            # Parse method block
-            for line in lines:
-                stripped = line.strip().lower()
-                if "d3bj" in stripped:
-                    block.parameters["dispersion"] = "D3BJ"
-                elif "d3" in stripped:
-                    block.parameters["dispersion"] = "D3"
-                elif "d4" in stripped:
-                    block.parameters["dispersion"] = "D4"
+    @staticmethod
+    def _parse_method(block: PercentBlock, content: str) -> None:
+        """Parse %method block parameters."""
+        for line in content.split("\n"):
+            stripped = line.strip().lower()
+            if "d3bj" in stripped:
+                block.parameters["dispersion"] = "D3BJ"
+            elif "d3" in stripped:
+                block.parameters["dispersion"] = "D3"
+            elif "d4" in stripped:
+                block.parameters["dispersion"] = "D4"
 
-        elif block.name == "scf":
-            # %scf settings
-            for line in lines:
-                stripped = line.strip().lower()
-                if "maxiter" in stripped:
-                    match = _MAXITER_RE.search(stripped)
-                    if match:
-                        block.parameters["maxiter"] = int(match.group(1))
+    def _parse_pal(self, block: PercentBlock, content: str) -> None:
+        """Parse %pal block parameters."""
+        self._parse_regex_param(block, content, "nprocs", _NPROCS_RE, "nprocs")
 
-        elif block.name == "eprnmr":
-            # %eprnmr settings
-            for line in lines:
-                stripped = line.strip().lower()
-                if "gtensor" in stripped:
-                    match = _GTENSOR_RE.search(stripped)
-                    if match:
-                        block.parameters["gtensor"] = int(match.group(1))
+    def _parse_scf(self, block: PercentBlock, content: str) -> None:
+        """Parse %scf block parameters."""
+        self._parse_regex_param(block, content, "maxiter", _MAXITER_RE, "maxiter")
 
-        elif block.name == "rirpa":
-            # %rirpa settings
-            for line in lines:
-                stripped = line.strip().lower()
-                if "nroots" in stripped:
-                    match = _NROOTS_RE.search(stripped)
-                    if match:
-                        block.parameters["nroots"] = int(match.group(1))
+    def _parse_eprnmr(self, block: PercentBlock, content: str) -> None:
+        """Parse %eprnmr block parameters."""
+        self._parse_regex_param(block, content, "gtensor", _GTENSOR_RE, "gtensor")
+
+    def _parse_rirpa(self, block: PercentBlock, content: str) -> None:
+        """Parse %rirpa block parameters."""
+        self._parse_regex_param(block, content, "nroots", _NROOTS_RE, "nroots")
 
     def parse_geometry(self, lines: List[str], start_line: int) -> Tuple[Optional[Geometry], int]:
         """Parse geometry section (* xyz ... *)"""

--- a/src/orca_lsp/server.py
+++ b/src/orca_lsp/server.py
@@ -47,9 +47,9 @@ _SORTED_ELEMENTS = tuple(sorted(ELEMENTS))
 class ORCALanguageServer(LanguageServer):
     """ORCA Language Server"""
 
-    def __init__(self) -> None:
+    def __init__(self, parser: Optional[ORCAParser] = None) -> None:
         super().__init__("orca-lsp", __version__)
-        self.parser = ORCAParser()
+        self.parser = parser if parser is not None else ORCAParser()
         self._setup_features()
 
     def _setup_features(self) -> None:
@@ -180,80 +180,66 @@ class ORCALanguageServer(LanguageServer):
 
         return completions
 
+    @staticmethod
+    def _create_completions(
+        items: dict, kind: CompletionItemKind, detail_key: str
+    ) -> List[CompletionItem]:
+        """Create completion items from a keyword dictionary.
+
+        Args:
+            items: Mapping of keyword name to info dict.
+            kind: The CompletionItemKind for all items.
+            detail_key: Key in the info dict for the detail text, or a literal
+                        string used when the info dict has no such key.
+        """
+        completions: List[CompletionItem] = []
+        for name, info in items.items():
+            detail = info.get(detail_key, detail_key)
+            completions.append(
+                CompletionItem(
+                    label=name,
+                    kind=kind,
+                    detail=detail,
+                    documentation=info.get("description", ""),
+                )
+            )
+        return completions
+
     def _get_method_completions(self) -> List[CompletionItem]:
         """Get method completions"""
-        completions: List[CompletionItem] = []
-
-        # DFT functionals
-        for name, info in DFT_FUNCTIONALS.items():
-            completions.append(
-                CompletionItem(
-                    label=name,
-                    kind=CompletionItemKind.Function,
-                    detail=f"DFT: {info.get('type', '')}",
-                    documentation=info.get("description", ""),
-                )
+        completions = self._create_completions(DFT_FUNCTIONALS, CompletionItemKind.Function, "type")
+        # Prefix DFT details for clarity
+        for item in completions:
+            if item.detail:
+                item.detail = f"DFT: {item.detail}"
+        completions.extend(
+            self._create_completions(
+                WAVEFUNCTION_METHODS, CompletionItemKind.Method, "type"
             )
-
-        # Wavefunction methods
-        for name, info in WAVEFUNCTION_METHODS.items():
-            completions.append(
-                CompletionItem(
-                    label=name,
-                    kind=CompletionItemKind.Method,
-                    detail="Wavefunction method",
-                    documentation=info.get("description", ""),
-                )
-            )
-
+        )
+        # Wavefunction methods get a fixed detail label
+        for item in completions[len(completions) - len(WAVEFUNCTION_METHODS) :]:
+            item.detail = "Wavefunction method"
         return completions
 
     def _get_basis_completions(self) -> List[CompletionItem]:
         """Get basis set completions"""
-        completions: List[CompletionItem] = []
-
-        for name, info in BASIS_SETS.items():
-            completions.append(
-                CompletionItem(
-                    label=name,
-                    kind=CompletionItemKind.Class,
-                    detail=info.get("type", ""),
-                    documentation=info.get("description", ""),
-                )
-            )
-
-        return completions
+        return self._create_completions(BASIS_SETS, CompletionItemKind.Class, "type")
 
     def _get_job_completions(self) -> List[CompletionItem]:
         """Get job type completions"""
-        completions: List[CompletionItem] = []
-
-        for name, info in JOB_TYPES.items():
-            completions.append(
-                CompletionItem(
-                    label=name,
-                    kind=CompletionItemKind.Event,
-                    detail="Job type",
-                    documentation=info.get("description", ""),
-                )
-            )
-
-        return completions
+        return self._create_completions(JOB_TYPES, CompletionItemKind.Event, "type")
 
     def _get_element_completions(self) -> List[CompletionItem]:
         """Get element symbol completions for geometry"""
-        completions: List[CompletionItem] = []
-
-        for element in _SORTED_ELEMENTS:
-            completions.append(
-                CompletionItem(
-                    label=element,
-                    kind=CompletionItemKind.EnumMember,
-                    detail=f"Element {element}",
-                )
+        return [
+            CompletionItem(
+                label=element,
+                kind=CompletionItemKind.EnumMember,
+                detail=f"Element {element}",
             )
-
-        return completions
+            for element in _SORTED_ELEMENTS
+        ]
 
     def _in_geometry_section(self, line: str) -> bool:
         """Check if we're in a geometry section"""
@@ -270,47 +256,36 @@ class ORCALanguageServer(LanguageServer):
         if not word:
             return None
 
-        # Look up documentation
+        # Look up documentation using unified lookup
         word_upper = word.upper()
 
-        # Check methods
-        if word_upper in DFT_FUNCTIONALS:
-            info = DFT_FUNCTIONALS[word_upper]
-            return Hover(
-                contents=MarkupContent(
-                    kind=MarkupKind.Markdown,
-                    value=f"**{word}**\n\n{info.get('description', '')}\n\nType: {info.get('type', 'N/A')}",
-                )
-            )
+        # Sources that include a Type line in hover output
+        type_sources = [DFT_FUNCTIONALS, BASIS_SETS]
+        # Sources that only show description
+        plain_sources = [WAVEFUNCTION_METHODS, JOB_TYPES]
 
-        if word_upper in WAVEFUNCTION_METHODS:
-            info = WAVEFUNCTION_METHODS[word_upper]
-            return Hover(
-                contents=MarkupContent(
-                    kind=MarkupKind.Markdown, value=f"**{word}**\n\n{info.get('description', '')}"
+        for source in type_sources:
+            if word_upper in source:
+                info = source[word_upper]
+                return Hover(
+                    contents=MarkupContent(
+                        kind=MarkupKind.Markdown,
+                        value=(
+                            f"**{word}**\n\n{info.get('description', '')}"
+                            f"\n\nType: {info.get('type', 'N/A')}"
+                        ),
+                    )
                 )
-            )
 
-        # Check basis sets
-        if word_upper in BASIS_SETS:
-            info = BASIS_SETS[
-                word_upper
-            ]  # pragma: no cover (hard to test due to hyphen in basis set names)
-            return Hover(
-                contents=MarkupContent(  # pragma: no cover (hard to test due to hyphen in basis set names)
-                    kind=MarkupKind.Markdown,
-                    value=f"**{word}**\n\n{info.get('description', '')}\n\nType: {info.get('type', 'N/A')}",
+        for source in plain_sources:
+            if word_upper in source:
+                info = source[word_upper]
+                return Hover(
+                    contents=MarkupContent(
+                        kind=MarkupKind.Markdown,
+                        value=f"**{word}**\n\n{info.get('description', '')}",
+                    )
                 )
-            )
-
-        # Check job types
-        if word_upper in JOB_TYPES:
-            info = JOB_TYPES[word_upper]
-            return Hover(
-                contents=MarkupContent(
-                    kind=MarkupKind.Markdown, value=f"**{word}**\n\n{info.get('description', '')}"
-                )
-            )
 
         return None
 
@@ -329,6 +304,22 @@ class ORCALanguageServer(LanguageServer):
 
         return str(line[start:end])
 
+    @staticmethod
+    def _create_diagnostic(
+        item: dict, severity: DiagnosticSeverity
+    ) -> Diagnostic:
+        """Create an LSP Diagnostic from a parsed error/warning item."""
+        line = item.get("line", 0)
+        return Diagnostic(
+            range=Range(
+                start=Position(line=line, character=0),
+                end=Position(line=line, character=100),
+            ),
+            message=item.get("message", ""),
+            severity=severity,
+            source="orca-lsp",
+        )
+
     def _validate_document(self, uri: str) -> None:
         """Validate a document and publish diagnostics"""
         document = self.workspace.get_text_document(uri)
@@ -338,33 +329,14 @@ class ORCALanguageServer(LanguageServer):
         result = self.parser.parse(content)
 
         # Convert to LSP diagnostics
-        diagnostics: List[Diagnostic] = []
-
-        for error in result.errors:
-            diagnostics.append(
-                Diagnostic(
-                    range=Range(
-                        start=Position(line=error.get("line", 0), character=0),
-                        end=Position(line=error.get("line", 0), character=100),
-                    ),
-                    message=error.get("message", ""),
-                    severity=DiagnosticSeverity.Error,
-                    source="orca-lsp",
-                )
-            )
-
-        for warning in result.warnings:
-            diagnostics.append(
-                Diagnostic(
-                    range=Range(
-                        start=Position(line=warning.get("line", 0), character=0),
-                        end=Position(line=warning.get("line", 0), character=100),
-                    ),
-                    message=warning.get("message", ""),
-                    severity=DiagnosticSeverity.Warning,
-                    source="orca-lsp",
-                )
-            )
+        diagnostics: List[Diagnostic] = [
+            self._create_diagnostic(error, DiagnosticSeverity.Error)
+            for error in result.errors
+        ]
+        diagnostics.extend(
+            self._create_diagnostic(warning, DiagnosticSeverity.Warning)
+            for warning in result.warnings
+        )
 
         # Publish diagnostics
         self.publish_diagnostics(uri, diagnostics)

--- a/src/orca_lsp/server.py
+++ b/src/orca_lsp/server.py
@@ -40,6 +40,9 @@ from .keywords import (
 )
 from .parser import ORCAParser
 
+# Pre-sorted elements for completions (avoid sorting on every request)
+_SORTED_ELEMENTS = tuple(sorted(ELEMENTS))
+
 
 class ORCALanguageServer(LanguageServer):
     """ORCA Language Server"""
@@ -122,10 +125,13 @@ class ORCALanguageServer(LanguageServer):
                     )
                 )
 
-        # Check if we're in a specific block
-        for name in PERCENT_BLOCKS.keys():
-            if f"%{name}" in line.lower():
-                completions.extend(self._get_block_specific_completions(name))
+        # Check if we're in a specific block - use regex to extract block name directly
+        # More efficient than looping through all block names
+        block_match = re.match(r"%(\w+)", line, re.IGNORECASE)
+        if block_match:
+            block_name = block_match.group(1).lower()
+            if block_name in PERCENT_BLOCKS:
+                completions.extend(self._get_block_specific_completions(block_name))
 
         return completions
 
@@ -238,7 +244,7 @@ class ORCALanguageServer(LanguageServer):
         """Get element symbol completions for geometry"""
         completions: List[CompletionItem] = []
 
-        for element in sorted(ELEMENTS):
+        for element in _SORTED_ELEMENTS:
             completions.append(
                 CompletionItem(
                     label=element,


### PR DESCRIPTION
## Summary

Addresses issue #16 — SOLID Principles Violations: Multiple Architectural Issues

### HIGH Priority Fixes (DRY):
- **Diagnostics DRY**: Extracted `_create_diagnostic(item, severity)` static method; error/warning loops now delegate to single helper
- **Completions DRY**: Extracted `_create_completions(items, kind, detail_key)` static method; method/basis/job completions now delegate to helper
- **Hover DRY**: Replaced four identical lookup patterns with loop over categorized sources

### MEDIUM Priority Fixes:
- **Dependency Injection**: `ORCALanguageServer.__init__` now accepts optional `parser` parameter (backward compatible)
- **Registry Pattern**: Replaced `if-elif` chain in `_parse_block_parameters` with `_block_handlers` dict; new block types can be added by registering a handler

### Test Results
All 353 existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)