### PR TITLE
fix: remove conflict markers accidentally merged into main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ htmlcov/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+.worktrees/

--- a/src/orca_lsp/parser.py
+++ b/src/orca_lsp/parser.py
@@ -267,15 +267,6 @@ class ORCAParser:
                 if match:
                     block.parameters[param_name] = int(match.group(1))
 
-<<<<<<< HEAD
-        elif block.name == "pal":
-            # %pal nprocs 4 end
-            for line in lines:
-                if "nprocs" in line.lower():
-                    match = _NPROCS_RE.search(line)
-                    if match:
-                        block.parameters["nprocs"] = int(match.group(1))
-=======
     @staticmethod
     def _parse_maxcore(block: PercentBlock, content: str) -> None:
         """Parse %maxcore block parameters."""
@@ -286,7 +277,6 @@ class ORCAParser:
                     block.parameters["memory"] = int(parts[1])
                 except ValueError:
                     pass
->>>>>>> origin/main
 
     @staticmethod
     def _parse_method(block: PercentBlock, content: str) -> None:
@@ -300,34 +290,6 @@ class ORCAParser:
             elif "d4" in stripped:
                 block.parameters["dispersion"] = "D4"
 
-<<<<<<< HEAD
-        elif block.name == "scf":
-            # %scf settings
-            for line in lines:
-                stripped = line.strip().lower()
-                if "maxiter" in stripped:
-                    match = _MAXITER_RE.search(stripped)
-                    if match:
-                        block.parameters["maxiter"] = int(match.group(1))
-
-        elif block.name == "eprnmr":
-            # %eprnmr settings
-            for line in lines:
-                stripped = line.strip().lower()
-                if "gtensor" in stripped:
-                    match = _GTENSOR_RE.search(stripped)
-                    if match:
-                        block.parameters["gtensor"] = int(match.group(1))
-
-        elif block.name == "rirpa":
-            # %rirpa settings
-            for line in lines:
-                stripped = line.strip().lower()
-                if "nroots" in stripped:
-                    match = _NROOTS_RE.search(stripped)
-                    if match:
-                        block.parameters["nroots"] = int(match.group(1))
-=======
     def _parse_pal(self, block: PercentBlock, content: str) -> None:
         """Parse %pal block parameters."""
         self._parse_regex_param(block, content, "nprocs", _NPROCS_RE, "nprocs")
@@ -343,7 +305,6 @@ class ORCAParser:
     def _parse_rirpa(self, block: PercentBlock, content: str) -> None:
         """Parse %rirpa block parameters."""
         self._parse_regex_param(block, content, "nroots", _NROOTS_RE, "nroots")
->>>>>>> origin/main
 
     def parse_geometry(self, lines: List[str], start_line: int) -> Tuple[Optional[Geometry], int]:
         """Parse geometry section (* xyz ... *)"""
@@ -374,20 +335,20 @@ class ORCAParser:
         while i < len(lines):
             line = lines[i].strip()
 
-            # End of geometry: bare '*' or '*' followed by trailing text/comment
+            # End of geometry (bare * or * with trailing text like "* end")
             if line == "*" or line.startswith("* "):
                 geom.line_end = i
                 break
 
-            # Skip inline comments in atom lines
-            comment_pos = line.find("!")
-            if comment_pos >= 0:
-                line = line[:comment_pos].strip()
-
-            # Skip empty lines
+            # Skip empty lines within geometry block
             if not line:
                 i += 1
                 continue
+
+            # Strip inline comments from atom lines (e.g., "H 0.0 0.0 0.0 ! hydrogen")
+            comment_pos = line.find("!")
+            if comment_pos >= 0:
+                line = line[:comment_pos].strip()
 
             # Parse atom
             atom_parts = line.split()

--- a/src/orca_lsp/server.py
+++ b/src/orca_lsp/server.py
@@ -43,11 +43,8 @@ from .parser import ORCAParser
 # Pre-sorted elements for completions (avoid sorting on every request)
 _SORTED_ELEMENTS = tuple(sorted(ELEMENTS))
 
-<<<<<<< HEAD
-=======
 # Regex for extracting %block name from a line (O(1) lookup vs O(n*m) loop)
 _PERCENT_BLOCK_NAME_RE = re.compile(r"%\s*(\w+)", re.IGNORECASE)
->>>>>>> origin/main
 
 class ORCALanguageServer(LanguageServer):
     """ORCA Language Server"""
@@ -132,15 +129,9 @@ class ORCALanguageServer(LanguageServer):
 
         # Check if we're in a specific block - use regex to extract block name directly
         # More efficient than looping through all block names
-<<<<<<< HEAD
-        block_match = re.match(r"%(\w+)", line, re.IGNORECASE)
-        if block_match:
-            block_name = block_match.group(1).lower()
-=======
         match = _PERCENT_BLOCK_NAME_RE.match(line)
         if match:
             block_name = match.group(1).lower()
->>>>>>> origin/main
             if block_name in PERCENT_BLOCKS:
                 completions.extend(self._get_block_specific_completions(block_name))
 
@@ -243,23 +234,11 @@ class ORCALanguageServer(LanguageServer):
 
     def _get_element_completions(self) -> List[CompletionItem]:
         """Get element symbol completions for geometry"""
-<<<<<<< HEAD
-        completions: List[CompletionItem] = []
-
-        for element in _SORTED_ELEMENTS:
-            completions.append(
-                CompletionItem(
-                    label=element,
-                    kind=CompletionItemKind.EnumMember,
-                    detail=f"Element {element}",
-                )
-=======
         return [
             CompletionItem(
                 label=element,
                 kind=CompletionItemKind.EnumMember,
                 detail=f"Element {element}",
->>>>>>> origin/main
             )
             for element in _SORTED_ELEMENTS
         ]


### PR DESCRIPTION
## Summary

PR #26 (issue #19) accidentally merged git conflict markers into `parser.py` and `server.py`. This PR cleans them up while preserving all intended changes:

- Inline comment stripping in `parse_simple_input` (from #26)
- Relaxed geometry terminator `*` detection (from #26)  
- All DRY/refactoring improvements from #25

Also adds `.worktrees/` to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)