### PR TITLE
chore: clean ORCA LSP quality gates

### DIFF
--- a/src/orca_lsp/features/agent_api.py
+++ b/src/orca_lsp/features/agent_api.py
@@ -18,29 +18,53 @@ class AgentAPISnapshot:
     metadata: Dict[str, Any] = field(default_factory=dict)
 
     def to_json(self) -> str:
-        return json.dumps({"uri": self.uri, "version": self.version,
-            "diagnostics": self.diagnostics, "outline": self.outline,
-            "metadata": self.metadata}, indent=2)
+        return json.dumps(
+            {
+                "uri": self.uri,
+                "version": self.version,
+                "diagnostics": self.diagnostics,
+                "outline": self.outline,
+                "metadata": self.metadata,
+            },
+            indent=2,
+        )
 
 
 def _diag_to_dict(d: Diagnostic) -> Dict[str, Any]:
-    return {"line": d.range.start.line, "character": d.range.start.character,
-        "severity": d.severity, "message": d.message, "code": d.code, "source": d.source}
+    return {
+        "line": d.range.start.line,
+        "character": d.range.start.character,
+        "severity": d.severity,
+        "message": d.message,
+        "code": d.code,
+        "source": d.source,
+    }
 
 
 class AgentAPIProvider:
     def __init__(self) -> None:
         pass
 
-    def get_snapshot(self, source: str, uri: str = "",
-        version: Optional[int] = None, diagnostics: Optional[List[Diagnostic]] = None,
+    def get_snapshot(
+        self,
+        source: str,
+        uri: str = "",
+        version: Optional[int] = None,
+        diagnostics: Optional[List[Diagnostic]] = None,
     ) -> AgentAPISnapshot:
         diag_dicts = [_diag_to_dict(d) for d in (diagnostics or [])]
         outline = self._build_outline(source)
-        return AgentAPISnapshot(uri=uri, version=version,
-            diagnostics=diag_dicts, outline=outline,
-            metadata={"language": "orca", "provider": "orca_lsp",
-                "feature_count": {"diagnostics": len(diag_dicts), "outline_items": len(outline)}})
+        return AgentAPISnapshot(
+            uri=uri,
+            version=version,
+            diagnostics=diag_dicts,
+            outline=outline,
+            metadata={
+                "language": "orca",
+                "provider": "orca_lsp",
+                "feature_count": {"diagnostics": len(diag_dicts), "outline_items": len(outline)},
+            },
+        )
 
     def _build_outline(self, source: str) -> List[Dict[str, Any]]:
         outline: List[Dict[str, Any]] = []
@@ -51,10 +75,14 @@ class AgentAPIProvider:
                 outline.append({"line": i, "text": stripped[:80], "type": "content"})
         return outline
 
-    def get_diagnostics_json(self, source: str, uri: str = "",
-        diagnostics: Optional[List[Diagnostic]] = None) -> str:
+    def get_diagnostics_json(
+        self, source: str, uri: str = "", diagnostics: Optional[List[Diagnostic]] = None
+    ) -> str:
         snap = self.get_snapshot(source, uri, diagnostics=diagnostics)
-        return json.dumps({"uri": snap.uri, "diagnostics": snap.diagnostics, "count": len(snap.diagnostics)}, indent=2)
+        return json.dumps(
+            {"uri": snap.uri, "diagnostics": snap.diagnostics, "count": len(snap.diagnostics)},
+            indent=2,
+        )
 
     def get_outline_json(self, source: str, uri: str = "") -> str:
         snap = self.get_snapshot(source, uri)

--- a/src/orca_lsp/features/code_actions.py
+++ b/src/orca_lsp/features/code_actions.py
@@ -207,7 +207,9 @@ class CodeActionProvider:
     # ------------------------------------------------------------------
 
     def _fix_unknown_token(
-        self, source: str, diagnostic: Diagnostic,
+        self,
+        source: str,
+        diagnostic: Diagnostic,
     ) -> Optional[CodeAction]:
         """Suggest replacement for unknown token in simple input."""
         unknown = self._extract_quoted_token(diagnostic.message)
@@ -246,7 +248,9 @@ class CodeActionProvider:
         )
 
     def _fix_unknown_block(
-        self, source: str, diagnostic: Diagnostic,
+        self,
+        source: str,
+        diagnostic: Diagnostic,
     ) -> Optional[CodeAction]:
         """Suggest replacement for unknown % block name."""
         block_name = self._extract_block_name(diagnostic.message)
@@ -282,7 +286,9 @@ class CodeActionProvider:
         )
 
     def _fix_unclosed_block(
-        self, source: str, diagnostic: Diagnostic,
+        self,
+        source: str,
+        diagnostic: Diagnostic,
     ) -> Optional[CodeAction]:
         """Add 'end' to close an unclosed % block."""
         lines = source.split("\n")
@@ -324,7 +330,9 @@ class CodeActionProvider:
         )
 
     def _fix_duplicate_block(
-        self, source: str, diagnostic: Diagnostic,
+        self,
+        source: str,
+        diagnostic: Diagnostic,
     ) -> Optional[CodeAction]:
         """Remove a duplicate % block."""
         lines = source.split("\n")
@@ -369,7 +377,9 @@ class CodeActionProvider:
         )
 
     def _fix_missing_maxcore(
-        self, source: str, diagnostic: Diagnostic,
+        self,
+        source: str,
+        diagnostic: Diagnostic,
     ) -> Optional[CodeAction]:
         """Add %maxcore with a recommended default value."""
         lines = source.split("\n")
@@ -399,7 +409,9 @@ class CodeActionProvider:
         )
 
     def _fix_duplicate_token(
-        self, source: str, diagnostic: Diagnostic,
+        self,
+        source: str,
+        diagnostic: Diagnostic,
     ) -> Optional[CodeAction]:
         """Remove a duplicate token in the simple input line."""
         diag_range = diagnostic.range
@@ -439,7 +451,9 @@ class CodeActionProvider:
         )
 
     def _fix_missing_section(
-        self, source: str, diagnostic: Diagnostic,
+        self,
+        source: str,
+        diagnostic: Diagnostic,
     ) -> Optional[CodeAction]:
         """Add a missing section stub (simple input or geometry)."""
         message = diagnostic.message.lower()
@@ -453,7 +467,9 @@ class CodeActionProvider:
         return None
 
     def _add_simple_input_stub(
-        self, source: str, diagnostic: Diagnostic,
+        self,
+        source: str,
+        diagnostic: Diagnostic,
     ) -> CodeAction:
         """Add a simple input line stub."""
         insert_pos = Position(line=0, character=0)
@@ -474,7 +490,9 @@ class CodeActionProvider:
         )
 
     def _add_geometry_stub(
-        self, source: str, diagnostic: Diagnostic,
+        self,
+        source: str,
+        diagnostic: Diagnostic,
     ) -> CodeAction:
         """Add a geometry section stub."""
         lines = source.split("\n")

--- a/src/orca_lsp/features/diagnostic.py
+++ b/src/orca_lsp/features/diagnostic.py
@@ -188,15 +188,15 @@ class DiagnosticProvider:
         Returns:
             Lowercase severity name.
         """
-        mapping = {
-            DiagnosticSeverity.Error: "error",
-            DiagnosticSeverity.Warning: "warning",
-            DiagnosticSeverity.Information: "information",
-            DiagnosticSeverity.Hint: "hint",
-        }
         if severity is None:
             return "error"
-        return mapping.get(severity, "error")
+        if severity == DiagnosticSeverity.Warning:
+            return "warning"
+        if severity == DiagnosticSeverity.Information:
+            return "information"
+        if severity == DiagnosticSeverity.Hint:
+            return "hint"
+        return "error"
 
 
 __all__ = ["DiagnosticProvider"]

--- a/src/orca_lsp/features/diagnostic.py
+++ b/src/orca_lsp/features/diagnostic.py
@@ -8,7 +8,6 @@ completion, hover, and formatting stay consistent.
 from __future__ import annotations
 
 import json
-from dataclasses import asdict
 from typing import Any, Dict, List, Optional
 
 from lsprotocol.types import (
@@ -150,9 +149,7 @@ class DiagnosticProvider:
             diagnostics.append(self._item_to_diagnostic(item, DiagnosticSeverity.Error))
 
         for item in result.warnings:
-            diagnostics.append(
-                self._item_to_diagnostic(item, DiagnosticSeverity.Warning)
-            )
+            diagnostics.append(self._item_to_diagnostic(item, DiagnosticSeverity.Warning))
 
         return diagnostics
 

--- a/src/orca_lsp/features/formatting.py
+++ b/src/orca_lsp/features/formatting.py
@@ -7,7 +7,6 @@ preserving comments, semantic content, and section ordering.
 
 from __future__ import annotations
 
-import re
 from typing import List, Optional
 
 from lsprotocol.types import (
@@ -23,9 +22,7 @@ from pygls.server import LanguageServer
 from ..keywords import PERCENT_BLOCKS
 
 # ORCA structural markers that affect indentation depth.
-_PERCENT_BLOCK_NAMES: frozenset[str] = frozenset(
-    name.lower() for name in PERCENT_BLOCKS
-)
+_PERCENT_BLOCK_NAMES: frozenset[str] = frozenset(name.lower() for name in PERCENT_BLOCKS)
 
 
 class FormattingProvider:
@@ -56,9 +53,7 @@ class FormattingProvider:
     # Public API
     # ------------------------------------------------------------------
 
-    def format_document(
-        self, text: str, params: DocumentFormattingParams
-    ) -> List[TextEdit]:
+    def format_document(self, text: str, params: DocumentFormattingParams) -> List[TextEdit]:
         """Format the entire document.
 
         Args:
@@ -93,9 +88,7 @@ class FormattingProvider:
             )
         ]
 
-    def format_range(
-        self, text: str, params: DocumentRangeFormattingParams
-    ) -> List[TextEdit]:
+    def format_range(self, text: str, params: DocumentRangeFormattingParams) -> List[TextEdit]:
         """Format a subrange of the document.
 
         To ensure correct indentation the formatter needs structural

--- a/src/orca_lsp/features/lint.py
+++ b/src/orca_lsp/features/lint.py
@@ -41,9 +41,7 @@ from lsprotocol.types import (
 
 from ..keywords import (
     ALL_KEYWORDS,
-    DFT_FUNCTIONALS,
     PERCENT_BLOCKS,
-    WAVEFUNCTION_METHODS,
 )
 from ..parser import ORCAParser, ParseResult, PercentBlock
 
@@ -260,9 +258,7 @@ class LintProvider:
                     Diagnostic(
                         range=Range(
                             start=Position(line=line_idx, character=col),
-                            end=Position(
-                                line=line_idx, character=col + len(token)
-                            ),
+                            end=Position(line=line_idx, character=col + len(token)),
                         ),
                         message=f"Unknown token in simple input: '{token}'",
                         severity=DiagnosticSeverity.Error,
@@ -272,22 +268,16 @@ class LintProvider:
                 )
             elif seen[token_upper] > 1:
                 # Only warn for the second and later occurrences.
-                first_idx = next(
-                    j for j, t in enumerate(tokens) if t.upper() == token_upper
-                )
+                first_idx = next(j for j, t in enumerate(tokens) if t.upper() == token_upper)
                 if i != first_idx:
                     col = self._token_column(raw_line, token, i)
                     diagnostics.append(
                         Diagnostic(
                             range=Range(
                                 start=Position(line=line_idx, character=col),
-                                end=Position(
-                                    line=line_idx, character=col + len(token)
-                                ),
+                                end=Position(line=line_idx, character=col + len(token)),
                             ),
-                            message=(
-                                f"Duplicate token in simple input: '{token}'"
-                            ),
+                            message=(f"Duplicate token in simple input: '{token}'"),
                             severity=DiagnosticSeverity.Warning,
                             source="orca-lsp-lint",
                             code=RULE_DUPLICATE_TOKEN,
@@ -345,24 +335,15 @@ class LintProvider:
         reported_duplicates: set[str] = set()
         for block in result.percent_blocks:
             name_lower = block.name.lower()
-            if (
-                seen_blocks.get(name_lower, 0) > 1
-                and name_lower not in reported_duplicates
-            ):
+            if seen_blocks.get(name_lower, 0) > 1 and name_lower not in reported_duplicates:
                 reported_duplicates.add(name_lower)
-                matches = [
-                    b
-                    for b in result.percent_blocks
-                    if b.name.lower() == name_lower
-                ]
+                matches = [b for b in result.percent_blocks if b.name.lower() == name_lower]
                 for dup_block in matches[1:]:
                     col = self._block_name_col(lines, dup_block.line_start)
                     diagnostics.append(
                         Diagnostic(
                             range=Range(
-                                start=Position(
-                                    line=dup_block.line_start, character=col
-                                ),
+                                start=Position(line=dup_block.line_start, character=col),
                                 end=Position(
                                     line=dup_block.line_start,
                                     character=col + len(dup_block.name) + 1,
@@ -404,9 +385,6 @@ class LintProvider:
 
             block_name = match.group(1).lower()
 
-            # Single-line value blocks (e.g. %maxcore 4000) are not multi-line.
-            rest = stripped[match.end():].strip()
-
             # If the line has "end", it's self-closing.
             if _end_re.search(stripped):
                 i += 1
@@ -417,9 +395,7 @@ class LintProvider:
             parts = stripped.split()
             if len(parts) == 2:
                 value = parts[1]
-                if value.isdigit() or (
-                    value.startswith('"') and value.endswith('"')
-                ):
+                if value.isdigit() or (value.startswith('"') and value.endswith('"')):
                     i += 1
                     continue
 
@@ -450,9 +426,7 @@ class LintProvider:
                     Diagnostic(
                         range=Range(
                             start=Position(line=i, character=col),
-                            end=Position(
-                                line=i, character=col + len(block_name) + 1
-                            ),
+                            end=Position(line=i, character=col + len(block_name) + 1),
                         ),
                         message=f"Unclosed % block: '%{block_name}'",
                         severity=DiagnosticSeverity.Error,
@@ -494,9 +468,7 @@ class LintProvider:
                 Diagnostic(
                     range=Range(
                         start=Position(line=line_idx, character=col),
-                        end=Position(
-                            line=line_idx, character=col + len(str(mult))
-                        ),
+                        end=Position(line=line_idx, character=col + len(str(mult))),
                     ),
                     message=f"Multiplicity must be >= 1, got {mult}",
                     severity=DiagnosticSeverity.Error,
@@ -580,14 +552,9 @@ class LintProvider:
                 Diagnostic(
                     range=Range(
                         start=Position(line=line_idx, character=col),
-                        end=Position(
-                            line=line_idx, character=col + len(val_str)
-                        ),
+                        end=Position(line=line_idx, character=col + len(val_str)),
                     ),
-                    message=(
-                        f"SCF maxiter {maxiter} is outside typical range "
-                        f"(10-5000)"
-                    ),
+                    message=(f"SCF maxiter {maxiter} is outside typical range " f"(10-5000)"),
                     severity=DiagnosticSeverity.Warning,
                     source="orca-lsp-lint",
                     code=RULE_MAXITER_RANGE,
@@ -616,13 +583,9 @@ class LintProvider:
                 Diagnostic(
                     range=Range(
                         start=Position(line=line_idx, character=col),
-                        end=Position(
-                            line=line_idx, character=col + len(val_str)
-                        ),
+                        end=Position(line=line_idx, character=col + len(val_str)),
                     ),
-                    message=(
-                        f"nprocs {nprocs} is unusually high (typical max: 256)"
-                    ),
+                    message=(f"nprocs {nprocs} is unusually high (typical max: 256)"),
                     severity=DiagnosticSeverity.Warning,
                     source="orca-lsp-lint",
                     code=RULE_NPROCS_HIGH,
@@ -651,14 +614,9 @@ class LintProvider:
                 Diagnostic(
                     range=Range(
                         start=Position(line=line_idx, character=col),
-                        end=Position(
-                            line=line_idx, character=col + len(val_str)
-                        ),
+                        end=Position(line=line_idx, character=col + len(val_str)),
                     ),
-                    message=(
-                        f"%maxcore {memory} MB is very low "
-                        f"(recommended: 1000-4000)"
-                    ),
+                    message=(f"%maxcore {memory} MB is very low " f"(recommended: 1000-4000)"),
                     severity=DiagnosticSeverity.Warning,
                     source="orca-lsp-lint",
                     code=RULE_MISSING_MAXCORE,
@@ -679,11 +637,7 @@ class LintProvider:
         Returns:
             Deterministic, JSON-safe dictionary.
         """
-        severity_value = (
-            diag.severity
-            if diag.severity is not None
-            else DiagnosticSeverity.Error
-        )
+        severity_value = diag.severity if diag.severity is not None else DiagnosticSeverity.Error
         return {
             "range": {
                 "start": {
@@ -785,15 +739,60 @@ class LintProvider:
             Total electron count, or None if elements are unknown.
         """
         _Z: Dict[str, int] = {
-            "H": 1, "He": 2, "Li": 3, "Be": 4, "B": 5, "C": 6, "N": 7,
-            "O": 8, "F": 9, "Ne": 10, "Na": 11, "Mg": 12, "Al": 13,
-            "Si": 14, "P": 15, "S": 16, "Cl": 17, "Ar": 18, "K": 19,
-            "Ca": 20, "Sc": 21, "Ti": 22, "V": 23, "Cr": 24, "Mn": 25,
-            "Fe": 26, "Co": 27, "Ni": 28, "Cu": 29, "Zn": 30, "Ga": 31,
-            "Ge": 32, "As": 33, "Se": 34, "Br": 35, "Kr": 36, "Rb": 37,
-            "Sr": 38, "Y": 39, "Zr": 40, "Nb": 41, "Mo": 42, "Tc": 43,
-            "Ru": 44, "Rh": 45, "Pd": 46, "Ag": 47, "Cd": 48, "In": 49,
-            "Sn": 50, "Sb": 51, "Te": 52, "I": 53, "Xe": 54,
+            "H": 1,
+            "He": 2,
+            "Li": 3,
+            "Be": 4,
+            "B": 5,
+            "C": 6,
+            "N": 7,
+            "O": 8,
+            "F": 9,
+            "Ne": 10,
+            "Na": 11,
+            "Mg": 12,
+            "Al": 13,
+            "Si": 14,
+            "P": 15,
+            "S": 16,
+            "Cl": 17,
+            "Ar": 18,
+            "K": 19,
+            "Ca": 20,
+            "Sc": 21,
+            "Ti": 22,
+            "V": 23,
+            "Cr": 24,
+            "Mn": 25,
+            "Fe": 26,
+            "Co": 27,
+            "Ni": 28,
+            "Cu": 29,
+            "Zn": 30,
+            "Ga": 31,
+            "Ge": 32,
+            "As": 33,
+            "Se": 34,
+            "Br": 35,
+            "Kr": 36,
+            "Rb": 37,
+            "Sr": 38,
+            "Y": 39,
+            "Zr": 40,
+            "Nb": 41,
+            "Mo": 42,
+            "Tc": 43,
+            "Ru": 44,
+            "Rh": 45,
+            "Pd": 46,
+            "Ag": 47,
+            "Cd": 48,
+            "In": 49,
+            "Sn": 50,
+            "Sb": 51,
+            "Te": 52,
+            "I": 53,
+            "Xe": 54,
         }
 
         total_z = 0
@@ -805,9 +804,7 @@ class LintProvider:
         return total_z - charge
 
     @staticmethod
-    def _find_param_line(
-        block: PercentBlock, param_name: str, lines: List[str]
-    ) -> int:
+    def _find_param_line(block: PercentBlock, param_name: str, lines: List[str]) -> int:
         """Find the line index of a parameter within a block.
 
         Args:

--- a/src/orca_lsp/features/navigation.py
+++ b/src/orca_lsp/features/navigation.py
@@ -25,10 +25,7 @@ from lsprotocol.types import (
 
 from ..parser import (
     ORCAParser,
-    ParseResult,
-    PercentBlock,
 )
-
 
 # ------------------------------------------------------------------
 # Helpers
@@ -59,6 +56,7 @@ def _position_in_range(pos: Position, rng: Range) -> bool:
 # ------------------------------------------------------------------
 # DefinitionProvider
 # ------------------------------------------------------------------
+
 
 class DefinitionProvider:
     """Provides go-to-definition for ORCA input files."""
@@ -129,7 +127,11 @@ class DefinitionProvider:
             if stripped.startswith("end") and i > current_block_start:
                 break
             for m in _WORD_RE.finditer(lines[i]):
-                if m.group().lower() == word_lower and m.start() < lines[i].lstrip().find(" ") if " " in lines[i].lstrip() else True:
+                if (
+                    m.group().lower() == word_lower and m.start() < lines[i].lstrip().find(" ")
+                    if " " in lines[i].lstrip()
+                    else True
+                ):
                     return Location(
                         uri="",
                         range=Range(
@@ -176,6 +178,7 @@ class DefinitionProvider:
 # HoverProvider
 # ------------------------------------------------------------------
 
+
 class HoverProvider:
     """Provides hover information for ORCA input files."""
 
@@ -194,14 +197,13 @@ class HoverProvider:
             return None
 
         word_upper = word.upper()
-        word_lower = word.lower()
 
         # Check keywords.py for documentation
         from ..keywords import (
-            DFT_FUNCTIONALS,
-            WAVEFUNCTION_METHODS,
             BASIS_SETS,
+            DFT_FUNCTIONALS,
             JOB_TYPES,
+            WAVEFUNCTION_METHODS,
         )
 
         # Check DFT functionals
@@ -209,7 +211,9 @@ class HoverProvider:
             info = DFT_FUNCTIONALS[word_upper]
             desc = info if isinstance(info, str) else "Density functional method"
             return Hover(
-                contents=MarkupContent(kind=MarkupKind.Markdown, value=f"**{word}** (DFT Functional)\n\n{desc}"),
+                contents=MarkupContent(
+                    kind=MarkupKind.Markdown, value=f"**{word}** (DFT Functional)\n\n{desc}"
+                ),
                 range=Range(
                     start=Position(line=position.line, character=0),
                     end=Position(line=position.line, character=len(line)),
@@ -218,9 +222,12 @@ class HoverProvider:
 
         # Check wavefunction methods
         if word_upper in WAVEFUNCTION_METHODS:
-            desc = WAVEFUNCTION_METHODS.get(word_upper, "Electronic structure method")
+            method_info = WAVEFUNCTION_METHODS.get(word_upper, "Electronic structure method")
+            desc = method_info if isinstance(method_info, str) else "Electronic structure method"
             return Hover(
-                contents=MarkupContent(kind=MarkupKind.Markdown, value=f"**{word}** (Wavefunction Method)\n\n{desc}"),
+                contents=MarkupContent(
+                    kind=MarkupKind.Markdown, value=f"**{word}** (Wavefunction Method)\n\n{desc}"
+                ),
                 range=Range(
                     start=Position(line=position.line, character=0),
                     end=Position(line=position.line, character=len(line)),
@@ -230,7 +237,10 @@ class HoverProvider:
         # Check job types
         if word_upper in JOB_TYPES:
             return Hover(
-                contents=MarkupContent(kind=MarkupKind.Markdown, value=f"**{word}** (Job Type)\n\n{JOB_TYPES[word_upper]}"),
+                contents=MarkupContent(
+                    kind=MarkupKind.Markdown,
+                    value=f"**{word}** (Job Type)\n\n{JOB_TYPES[word_upper]}",
+                ),
                 range=Range(
                     start=Position(line=position.line, character=0),
                     end=Position(line=position.line, character=len(line)),
@@ -240,7 +250,10 @@ class HoverProvider:
         # Check basis sets
         if word_upper in BASIS_SETS:
             return Hover(
-                contents=MarkupContent(kind=MarkupKind.Markdown, value=f"**{word}** (Basis Set)\n\n{BASIS_SETS[word_upper]}"),
+                contents=MarkupContent(
+                    kind=MarkupKind.Markdown,
+                    value=f"**{word}** (Basis Set)\n\n{BASIS_SETS[word_upper]}",
+                ),
                 range=Range(
                     start=Position(line=position.line, character=0),
                     end=Position(line=position.line, character=len(line)),
@@ -273,7 +286,10 @@ class HoverProvider:
             }
             if block_name in descriptions:
                 return Hover(
-                    contents=MarkupContent(kind=MarkupKind.Markdown, value=f"**%{block_name}**\n\n{descriptions[block_name]}"),
+                    contents=MarkupContent(
+                        kind=MarkupKind.Markdown,
+                        value=f"**%{block_name}**\n\n{descriptions[block_name]}",
+                    ),
                     range=Range(
                         start=Position(line=position.line, character=0),
                         end=Position(line=position.line, character=len(line)),
@@ -286,6 +302,7 @@ class HoverProvider:
 # ------------------------------------------------------------------
 # ReferencesProvider
 # ------------------------------------------------------------------
+
 
 class ReferencesProvider:
     """Provides find-references for ORCA input files."""
@@ -318,7 +335,11 @@ class ReferencesProvider:
             for m in _WORD_RE.finditer(l):
                 if m.group().lower() == word_lower:
                     # Exact case-insensitive match
-                    if not include_declaration and i == position.line and m.start() == position.character:
+                    if (
+                        not include_declaration
+                        and i == position.line
+                        and m.start() == position.character
+                    ):
                         continue
                     locations.append(
                         Location(

--- a/src/orca_lsp/features/regression.py
+++ b/src/orca_lsp/features/regression.py
@@ -16,11 +16,13 @@ class GoldenFixture:
     expected_diagnostics: List[Dict[str, Any]] = field(default_factory=list)
     metadata: Dict[str, Any] = field(default_factory=dict)
 
+
 @dataclass
 class RegressionResult:
     name: str
     passed: bool
     mismatches: List[str] = field(default_factory=list)
+
 
 class RegressionHarness:
     def __init__(self) -> None:
@@ -32,15 +34,24 @@ class RegressionHarness:
     def run_fixture(self, name: str) -> RegressionResult:
         fixture = self._fixtures.get(name)
         if fixture is None:
-            return RegressionResult(name=name, passed=False, mismatches=[f"Fixture '{name}' not found"])
+            return RegressionResult(
+                name=name, passed=False, mismatches=[f"Fixture '{name}' not found"]
+            )
         return RegressionResult(name=name, passed=True)
 
     def run_all(self) -> List[RegressionResult]:
         return [self.run_fixture(n) for n in self._fixtures]
 
-    def snapshot_fixture(self, name: str, source: str, diagnostics: Optional[List[Diagnostic]] = None) -> str:
-        diag_dicts = [{"line": d.range.start.line, "message": d.message, "code": d.code} for d in (diagnostics or [])]
-        return json.dumps({"name": name, "input_source": source, "expected_diagnostics": diag_dicts}, indent=2)
+    def snapshot_fixture(
+        self, name: str, source: str, diagnostics: Optional[List[Diagnostic]] = None
+    ) -> str:
+        diag_dicts = [
+            {"line": d.range.start.line, "message": d.message, "code": d.code}
+            for d in (diagnostics or [])
+        ]
+        return json.dumps(
+            {"name": name, "input_source": source, "expected_diagnostics": diag_dicts}, indent=2
+        )
 
     @property
     def fixture_count(self) -> int:

--- a/src/orca_lsp/features/rename.py
+++ b/src/orca_lsp/features/rename.py
@@ -161,9 +161,7 @@ def _is_valid_new_name(name: str) -> bool:
     return bool(re.match(r"^[A-Za-z_][\w\-\.\(\)]*$", name))
 
 
-def _collect_block_name_occurrences(
-    text: str, block_name: str
-) -> List[SymbolOccurrence]:
+def _collect_block_name_occurrences(text: str, block_name: str) -> List[SymbolOccurrence]:
     """Find every occurrence of a ``%`` block name in *text*."""
     occurrences: List[SymbolOccurrence] = []
     name_lower = block_name.lower()
@@ -190,9 +188,7 @@ def _collect_block_name_occurrences(
     return occurrences
 
 
-def _collect_simple_input_keyword_occurrences(
-    text: str, keyword: str
-) -> List[SymbolOccurrence]:
+def _collect_simple_input_keyword_occurrences(text: str, keyword: str) -> List[SymbolOccurrence]:
     """Find every occurrence of a keyword in ``!`` simple-input lines."""
     occurrences: List[SymbolOccurrence] = []
     lines = text.split("\n")
@@ -236,9 +232,7 @@ def _collect_simple_input_keyword_occurrences(
     return occurrences
 
 
-def _collect_block_param_occurrences(
-    text: str, param_name: str
-) -> List[SymbolOccurrence]:
+def _collect_block_param_occurrences(text: str, param_name: str) -> List[SymbolOccurrence]:
     """Find every occurrence of a ``%`` block parameter in *text*."""
     occurrences: List[SymbolOccurrence] = []
     param_lower = param_name.lower()
@@ -261,9 +255,7 @@ def _collect_block_param_occurrences(
                 in_block = False
 
             # Scan for the parameter on the % header line itself
-            _scan_line_for_param(
-                occurrences, line_idx, line, stripped, param_lower
-            )
+            _scan_line_for_param(occurrences, line_idx, line, stripped, param_lower)
             continue
 
         if in_block:
@@ -271,9 +263,7 @@ def _collect_block_param_occurrences(
                 in_block = False
                 continue
 
-            _scan_line_for_param(
-                occurrences, line_idx, line, stripped, param_lower
-            )
+            _scan_line_for_param(occurrences, line_idx, line, stripped, param_lower)
 
     return occurrences
 
@@ -286,9 +276,7 @@ def _scan_line_for_param(
     param_lower: str,
 ) -> None:
     """Scan a single line for a parameter keyword match and append occurrences."""
-    for m in re.finditer(
-        r"\b(" + re.escape(param_lower) + r")\b", stripped, re.IGNORECASE
-    ):
+    for m in re.finditer(r"\b(" + re.escape(param_lower) + r")\b", stripped, re.IGNORECASE):
         if m.group(1).lower() == param_lower:
             # Map match position back to the original (unstripped) line
             line_offset = len(line) - len(line.lstrip())
@@ -301,8 +289,6 @@ def _scan_line_for_param(
                     kind="block_param",
                 )
             )
-
-    return occurrences
 
 
 # ---------------------------------------------------------------------------

--- a/src/orca_lsp/features/test_runner.py
+++ b/src/orca_lsp/features/test_runner.py
@@ -18,6 +18,7 @@ class TestRunnerConfig:
     executable: str = ""
     timeout: float = 30.0
     enabled: bool = False
+
     def validate(self) -> List[str]:
         errors: List[str] = []
         if self.enabled and not self.executable:
@@ -52,7 +53,8 @@ def parse_solver_output(raw: str) -> SolverOutput:
             message = match.group(0).strip()
             line_num = 0
             lm = _LINE_NUM_RE.search(message)
-            if lm: line_num = int(lm.group(1)) - 1
+            if lm:
+                line_num = int(lm.group(1)) - 1
             entry = {"message": message, "line": line_num, "source": "orca-test-runner"}
             (errors if severity == "error" else warnings).append(entry)
     return SolverOutput(success=len(errors) == 0, raw_output=raw, errors=errors, warnings=warnings)
@@ -61,11 +63,25 @@ def parse_solver_output(raw: str) -> SolverOutput:
 def solver_output_to_diagnostics(output: SolverOutput) -> List[Diagnostic]:
     diags: List[Diagnostic] = []
     for e in output.errors:
-        diags.append(Diagnostic(range=Range(start=Position(e["line"], 0), end=Position(e["line"], 999)),
-            message=e["message"], severity=DiagnosticSeverity.Error, source="orca-test-runner", code="ORCA9001"))
+        diags.append(
+            Diagnostic(
+                range=Range(start=Position(e["line"], 0), end=Position(e["line"], 999)),
+                message=e["message"],
+                severity=DiagnosticSeverity.Error,
+                source="orca-test-runner",
+                code="ORCA9001",
+            )
+        )
     for w in output.warnings:
-        diags.append(Diagnostic(range=Range(start=Position(w["line"], 0), end=Position(w["line"], 999)),
-            message=w["message"], severity=DiagnosticSeverity.Warning, source="orca-test-runner", code="ORCA9002"))
+        diags.append(
+            Diagnostic(
+                range=Range(start=Position(w["line"], 0), end=Position(w["line"], 999)),
+                message=w["message"],
+                severity=DiagnosticSeverity.Warning,
+                source="orca-test-runner",
+                code="ORCA9002",
+            )
+        )
     return diags
 
 
@@ -74,49 +90,97 @@ class TestRunnerProvider:
         self._config = config or TestRunnerConfig()
 
     @property
-    def config(self) -> TestRunnerConfig: return self._config
+    def config(self) -> TestRunnerConfig:
+        return self._config
 
     @config.setter
-    def config(self, value: TestRunnerConfig) -> None: self._config = value
+    def config(self, value: TestRunnerConfig) -> None:
+        self._config = value
 
-    def validate_config(self) -> List[str]: return self._config.validate()
+    def validate_config(self) -> List[str]:
+        return self._config.validate()
 
     def run_validation(self, source: str) -> List[Diagnostic]:
         if not self._config.enabled:
-            return [Diagnostic(range=Range(start=Position(0, 0), end=Position(0, 0)),
-                message="ORCA test runner not enabled.", severity=DiagnosticSeverity.Information,
-                source="orca-test-runner", code="ORCA9000")]
+            return [
+                Diagnostic(
+                    range=Range(start=Position(0, 0), end=Position(0, 0)),
+                    message="ORCA test runner not enabled.",
+                    severity=DiagnosticSeverity.Information,
+                    source="orca-test-runner",
+                    code="ORCA9000",
+                )
+            ]
         if not self._config.executable:
-            return [Diagnostic(range=Range(start=Position(0, 0), end=Position(0, 0)),
-                message="ORCA executable not configured.", severity=DiagnosticSeverity.Warning,
-                source="orca-test-runner", code="ORCA9000")]
+            return [
+                Diagnostic(
+                    range=Range(start=Position(0, 0), end=Position(0, 0)),
+                    message="ORCA executable not configured.",
+                    severity=DiagnosticSeverity.Warning,
+                    source="orca-test-runner",
+                    code="ORCA9000",
+                )
+            ]
         import shutil
+
         if not shutil.which(self._config.executable):
-            return [Diagnostic(range=Range(start=Position(0, 0), end=Position(0, 0)),
-                message=f"ORCA executable not found: {self._config.executable}",
-                severity=DiagnosticSeverity.Error, source="orca-test-runner", code="ORCA9000")]
+            return [
+                Diagnostic(
+                    range=Range(start=Position(0, 0), end=Position(0, 0)),
+                    message=f"ORCA executable not found: {self._config.executable}",
+                    severity=DiagnosticSeverity.Error,
+                    source="orca-test-runner",
+                    code="ORCA9000",
+                )
+            ]
         try:
             with tempfile.NamedTemporaryFile(mode="w", suffix=".inp", delete=False) as f:
-                f.write(source); temp_path = f.name
-            result = subprocess.run([self._config.executable, temp_path],
-                capture_output=True, text=True, timeout=self._config.timeout)
-            return solver_output_to_diagnostics(parse_solver_output(result.stdout + "\n" + result.stderr))
+                f.write(source)
+                temp_path = f.name
+            result = subprocess.run(
+                [self._config.executable, temp_path],
+                capture_output=True,
+                text=True,
+                timeout=self._config.timeout,
+            )
+            return solver_output_to_diagnostics(
+                parse_solver_output(result.stdout + "\n" + result.stderr)
+            )
         except subprocess.TimeoutExpired:
-            return [Diagnostic(range=Range(start=Position(0, 0), end=Position(0, 0)),
-                message=f"ORCA timed out after {self._config.timeout}s.",
-                severity=DiagnosticSeverity.Warning, source="orca-test-runner", code="ORCA9003")]
+            return [
+                Diagnostic(
+                    range=Range(start=Position(0, 0), end=Position(0, 0)),
+                    message=f"ORCA timed out after {self._config.timeout}s.",
+                    severity=DiagnosticSeverity.Warning,
+                    source="orca-test-runner",
+                    code="ORCA9003",
+                )
+            ]
         except FileNotFoundError:
-            return [Diagnostic(range=Range(start=Position(0, 0), end=Position(0, 0)),
-                message=f"ORCA not found: {self._config.executable}",
-                severity=DiagnosticSeverity.Error, source="orca-test-runner", code="ORCA9000")]
+            return [
+                Diagnostic(
+                    range=Range(start=Position(0, 0), end=Position(0, 0)),
+                    message=f"ORCA not found: {self._config.executable}",
+                    severity=DiagnosticSeverity.Error,
+                    source="orca-test-runner",
+                    code="ORCA9000",
+                )
+            ]
         finally:
-            try: Path(temp_path).unlink()
-            except (NameError, FileNotFoundError): pass
+            try:
+                Path(temp_path).unlink()
+            except (NameError, FileNotFoundError):
+                pass
 
     def run_with_captured_output(self, captured_output: str) -> List[Diagnostic]:
         return solver_output_to_diagnostics(parse_solver_output(captured_output))
 
     def snapshot_config(self) -> str:
-        return json.dumps({"enabled": self._config.enabled,
-            "executable": self._config.executable or "(not configured)",
-            "timeout": self._config.timeout}, indent=2)
+        return json.dumps(
+            {
+                "enabled": self._config.enabled,
+                "executable": self._config.executable or "(not configured)",
+                "timeout": self._config.timeout,
+            },
+            indent=2,
+        )

--- a/src/orca_lsp/features/typecheck.py
+++ b/src/orca_lsp/features/typecheck.py
@@ -34,7 +34,6 @@ from ..keywords import (
     BASIS_SETS,
     DFT_FUNCTIONALS,
     JOB_TYPES,
-    PERCENT_BLOCKS,
     WAVEFUNCTION_METHODS,
 )
 from ..parser import ORCAParser, ParseResult, PercentBlock
@@ -176,9 +175,7 @@ _VALID_UNITS: Dict[str, Dict[str, Set[str]]] = {
 }
 
 # Enum validation sets for simple-input keywords (case-insensitive check)
-_METHOD_ENUM: Set[str] = (
-    set(DFT_FUNCTIONALS.keys()) | set(WAVEFUNCTION_METHODS.keys())
-)
+_METHOD_ENUM: Set[str] = set(DFT_FUNCTIONALS.keys()) | set(WAVEFUNCTION_METHODS.keys())
 _METHOD_ENUM_UPPER: Set[str] = {m.upper() for m in _METHOD_ENUM}
 
 _BASIS_ENUM_UPPER: Set[str] = {b.upper() for b in BASIS_SETS.keys()}
@@ -190,27 +187,48 @@ _DISPERSION_ENUM_UPPER: Set[str] = {"D3", "D3BJ", "D4"}
 _SOLVENT_ENUM_UPPER: Set[str] = {"CPCM", "SMD"}
 
 _SCF_CONV_ENUM_UPPER: Set[str] = {
-    "TIGHTSCF", "LOOSESCF", "VERYTIGHTSCF", "SLOPPYSCF", "NORMALSCF",
+    "TIGHTSCF",
+    "LOOSESCF",
+    "VERYTIGHTSCF",
+    "SLOPPYSCF",
+    "NORMALSCF",
 }
 
 _BOOLEAN_STRINGS: Set[str] = {"true", "false", "1", "0", "yes", "no"}
 
 # All known simple-input modifiers (not in method/basis/job dictionaries)
 _KNOWN_MODIFIERS_UPPER: Set[str] = {
-    "RIJCOSX", "RI-J", "GRID3", "GRID4", "GRID5",
-    "FINALGRID4", "FINALGRID5", "FINALGRID6",
-    "DEFGRID2", "DEFGRID3", "NOITER",
-    "PRINTLEVEL", "MOREAD", "KEEPDENS", "KEEPMOS",
-    "MINIPRINT", "LARGEPRINT", "NOPRINT",
-    "DFT", "RKS", "UKS", "ROKS",
-    "ZORA", "DKH",
-    "RHF", "UHF", "ROHF",
+    "RIJCOSX",
+    "RI-J",
+    "GRID3",
+    "GRID4",
+    "GRID5",
+    "FINALGRID4",
+    "FINALGRID5",
+    "FINALGRID6",
+    "DEFGRID2",
+    "DEFGRID3",
+    "NOITER",
+    "PRINTLEVEL",
+    "MOREAD",
+    "KEEPDENS",
+    "KEEPMOS",
+    "MINIPRINT",
+    "LARGEPRINT",
+    "NOPRINT",
+    "DFT",
+    "RKS",
+    "UKS",
+    "ROKS",
+    "ZORA",
+    "DKH",
+    "RHF",
+    "UHF",
+    "ROHF",
 }
 
 # Regex for extracting block parameter assignments
-_PARAM_ASSIGNMENT_RE = re.compile(
-    r"^\s*(\w+)\s+(.+?)(?:\s+#.*)?$", re.IGNORECASE
-)
+_PARAM_ASSIGNMENT_RE = re.compile(r"^\s*(\w+)\s+(.+?)(?:\s+#.*)?$", re.IGNORECASE)
 
 # Regex for matching a unit suffix like "MB", "GB", "K", "fs", "ps"
 _UNIT_SUFFIX_RE = re.compile(r"^(-?[\d.]+)\s*([A-Za-z]+)$")
@@ -344,14 +362,9 @@ class TypecheckProvider:
                     Diagnostic(
                         range=Range(
                             start=Position(line=line_idx, character=col),
-                            end=Position(
-                                line=line_idx, character=col + len(token)
-                            ),
+                            end=Position(line=line_idx, character=col + len(token)),
                         ),
-                        message=(
-                            f"Unknown keyword '{token}'. "
-                            f"Did you mean '{suggestion}'?"
-                        ),
+                        message=(f"Unknown keyword '{token}'. " f"Did you mean '{suggestion}'?"),
                         severity=DiagnosticSeverity.Error,
                         source="orca-lsp-typecheck",
                         code=RULE_INVALID_ENUM,
@@ -368,9 +381,7 @@ class TypecheckProvider:
             Best matching known keyword if close enough, else None.
         """
         candidates: List[Tuple[int, str]] = []
-        all_known = (
-            _METHOD_ENUM_UPPER | _BASIS_ENUM_UPPER | _JOB_TYPE_ENUM_UPPER
-        )
+        all_known = _METHOD_ENUM_UPPER | _BASIS_ENUM_UPPER | _JOB_TYPE_ENUM_UPPER
         for known in all_known:
             dist = self._levenshtein(token_upper, known)
             if dist <= max(2, len(token_upper) // 3):
@@ -440,7 +451,11 @@ class TypecheckProvider:
             # Check if this is a single-line value block (e.g. %maxcore 4000)
             first_line = block.raw_content.split("\n")[0].strip()
             self._check_single_line_block(
-                block, first_line, schema, lines, diagnostics,
+                block,
+                first_line,
+                schema,
+                lines,
+                diagnostics,
             )
 
             # Check multi-line content (lines not starting with %)
@@ -464,6 +479,8 @@ class TypecheckProvider:
                     continue
 
                 expected_type = param_schema.get("type")
+                if not isinstance(expected_type, str):
+                    continue
                 abs_line_idx = block.line_start + rel_line_idx
 
                 self._validate_param_value(
@@ -516,7 +533,7 @@ class TypecheckProvider:
             # Single value -- look for the first schema param
             for param_name, param_schema in schema.items():
                 expected_type = param_schema.get("type")
-                if expected_type in ("int", "float"):
+                if isinstance(expected_type, str) and expected_type in ("int", "float"):
                     self._validate_param_value(
                         param_name,
                         parts[0],
@@ -533,13 +550,15 @@ class TypecheckProvider:
             param_name_raw = parts[0]
             param_value_raw = parts[1].strip()
             param_name_lower = param_name_raw.lower()
-            param_schema = schema.get(param_name_lower)
-            if param_schema is not None:
-                expected_type = param_schema.get("type")
+            inline_param_schema = schema.get(param_name_lower)
+            if inline_param_schema is not None:
+                expected_type = inline_param_schema.get("type")
+                if not isinstance(expected_type, str):
+                    return
                 self._validate_param_value(
                     param_name_raw,
                     param_value_raw,
-                    param_schema,
+                    inline_param_schema,
                     expected_type,
                     block.line_start,
                     block.name,
@@ -591,23 +610,44 @@ class TypecheckProvider:
 
         if expected_type == "int":
             self._validate_int(
-                param_value, param_name, schema, line_idx, col,
-                val_end_col, block_name, diagnostics,
+                param_value,
+                param_name,
+                schema,
+                line_idx,
+                col,
+                val_end_col,
+                block_name,
+                diagnostics,
             )
         elif expected_type == "float":
             self._validate_float(
-                param_value, param_name, schema, line_idx, col,
-                val_end_col, block_name, diagnostics,
+                param_value,
+                param_name,
+                schema,
+                line_idx,
+                col,
+                val_end_col,
+                block_name,
+                diagnostics,
             )
         elif expected_type == "bool":
             self._validate_bool(
-                param_value, param_name, line_idx, col,
-                val_end_col, diagnostics,
+                param_value,
+                param_name,
+                line_idx,
+                col,
+                val_end_col,
+                diagnostics,
             )
         elif expected_type == "enum":
             self._validate_enum(
-                param_value, param_name, schema, line_idx, col,
-                val_end_col, diagnostics,
+                param_value,
+                param_name,
+                schema,
+                line_idx,
+                col,
+                val_end_col,
+                diagnostics,
             )
 
     def _validate_int(
@@ -645,8 +685,7 @@ class TypecheckProvider:
                         end=Position(line=line_idx, character=end_col),
                     ),
                     message=(
-                        f"Expected integer for '%{block_name} {param_name}', "
-                        f"got '{value}'"
+                        f"Expected integer for '%{block_name} {param_name}', " f"got '{value}'"
                     ),
                     severity=DiagnosticSeverity.Error,
                     source="orca-lsp-typecheck",
@@ -664,10 +703,7 @@ class TypecheckProvider:
                         start=Position(line=line_idx, character=col),
                         end=Position(line=line_idx, character=end_col),
                     ),
-                    message=(
-                        f"Value {int_val} for '{param_name}' is below "
-                        f"minimum {min_val}"
-                    ),
+                    message=(f"Value {int_val} for '{param_name}' is below " f"minimum {min_val}"),
                     severity=DiagnosticSeverity.Warning,
                     source="orca-lsp-typecheck",
                     code=RULE_NON_NUMERIC,
@@ -680,10 +716,7 @@ class TypecheckProvider:
                         start=Position(line=line_idx, character=col),
                         end=Position(line=line_idx, character=end_col),
                     ),
-                    message=(
-                        f"Value {int_val} for '{param_name}' is above "
-                        f"maximum {max_val}"
-                    ),
+                    message=(f"Value {int_val} for '{param_name}' is above " f"maximum {max_val}"),
                     severity=DiagnosticSeverity.Warning,
                     source="orca-lsp-typecheck",
                     code=RULE_NON_NUMERIC,
@@ -724,8 +757,7 @@ class TypecheckProvider:
                         end=Position(line=line_idx, character=end_col),
                     ),
                     message=(
-                        f"Expected number for '%{block_name} {param_name}', "
-                        f"got '{value}'"
+                        f"Expected number for '%{block_name} {param_name}', " f"got '{value}'"
                     ),
                     severity=DiagnosticSeverity.Error,
                     source="orca-lsp-typecheck",
@@ -744,8 +776,7 @@ class TypecheckProvider:
                         end=Position(line=line_idx, character=end_col),
                     ),
                     message=(
-                        f"Value {float_val} for '{param_name}' is below "
-                        f"minimum {min_val}"
+                        f"Value {float_val} for '{param_name}' is below " f"minimum {min_val}"
                     ),
                     severity=DiagnosticSeverity.Warning,
                     source="orca-lsp-typecheck",
@@ -760,8 +791,7 @@ class TypecheckProvider:
                         end=Position(line=line_idx, character=end_col),
                     ),
                     message=(
-                        f"Value {float_val} for '{param_name}' is above "
-                        f"maximum {max_val}"
+                        f"Value {float_val} for '{param_name}' is above " f"maximum {max_val}"
                     ),
                     severity=DiagnosticSeverity.Warning,
                     source="orca-lsp-typecheck",
@@ -796,8 +826,7 @@ class TypecheckProvider:
                         end=Position(line=line_idx, character=end_col),
                     ),
                     message=(
-                        f"Expected boolean (true/false) for '{param_name}', "
-                        f"got '{value}'"
+                        f"Expected boolean (true/false) for '{param_name}', " f"got '{value}'"
                     ),
                     severity=DiagnosticSeverity.Error,
                     source="orca-lsp-typecheck",
@@ -871,7 +900,10 @@ class TypecheckProvider:
 
             # Check single-line blocks (value on % line)
             self._check_single_line_units(
-                block, valid_units, lines, diagnostics,
+                block,
+                valid_units,
+                lines,
+                diagnostics,
             )
 
             # Check multi-line parameter assignments
@@ -894,8 +926,12 @@ class TypecheckProvider:
                     continue
 
                 self._check_unit_value(
-                    param_value_raw, param_name_raw, allowed_units,
-                    block.line_start + rel_line_idx, lines, diagnostics,
+                    param_value_raw,
+                    param_name_raw,
+                    allowed_units,
+                    block.line_start + rel_line_idx,
+                    lines,
+                    diagnostics,
                 )
 
     def _check_single_line_units(
@@ -937,14 +973,17 @@ class TypecheckProvider:
                     unit_str = unit_match.group(2)
                     if unit_str not in allowed_units:
                         col = self._find_value_col(
-                            lines, block.line_start,
-                            block.name, parts[0],
+                            lines,
+                            block.line_start,
+                            block.name,
+                            parts[0],
                         )
                         diagnostics.append(
                             Diagnostic(
                                 range=Range(
                                     start=Position(
-                                        line=block.line_start, character=col,
+                                        line=block.line_start,
+                                        character=col,
                                     ),
                                     end=Position(
                                         line=block.line_start,
@@ -966,11 +1005,15 @@ class TypecheckProvider:
             # Inline param (e.g. %pal nprocs 4)
             param_name_lower = parts[0].lower()
             param_value = parts[1].strip()
-            allowed_units = valid_units.get(param_name_lower)
-            if allowed_units is not None:
+            inline_allowed_units = valid_units.get(param_name_lower)
+            if inline_allowed_units is not None:
                 self._check_unit_value(
-                    param_value, parts[0], allowed_units,
-                    block.line_start, lines, diagnostics,
+                    param_value,
+                    parts[0],
+                    inline_allowed_units,
+                    block.line_start,
+                    lines,
+                    diagnostics,
                 )
 
     def _check_unit_value(
@@ -997,13 +1040,17 @@ class TypecheckProvider:
             unit_str = unit_match.group(2)
             if unit_str not in allowed_units:
                 col = self._find_value_col(
-                    lines, line_idx, param_name, value,
+                    lines,
+                    line_idx,
+                    param_name,
+                    value,
                 )
                 diagnostics.append(
                     Diagnostic(
                         range=Range(
                             start=Position(
-                                line=line_idx, character=col,
+                                line=line_idx,
+                                character=col,
                             ),
                             end=Position(
                                 line=line_idx,
@@ -1053,8 +1100,7 @@ class TypecheckProvider:
                         end=Position(line=0, character=0),
                     ),
                     message=(
-                        "Missing required simple input line "
-                        "(e.g. '! B3LYP def2-TZVP OPT')"
+                        "Missing required simple input line " "(e.g. '! B3LYP def2-TZVP OPT')"
                     ),
                     severity=DiagnosticSeverity.Warning,
                     source="orca-lsp-typecheck",
@@ -1128,8 +1174,7 @@ class TypecheckProvider:
                         ),
                     ),
                     message=(
-                        "Missing required geometry section "
-                        "(e.g. '* xyz 0 1\\n  H 0 0 0\\n*')"
+                        "Missing required geometry section " "(e.g. '* xyz 0 1\\n  H 0 0 0\\n*')"
                     ),
                     severity=DiagnosticSeverity.Warning,
                     source="orca-lsp-typecheck",
@@ -1143,7 +1188,9 @@ class TypecheckProvider:
 
     @staticmethod
     def _strip_unit(
-        value: str, block_name: str, param_name: str,
+        value: str,
+        block_name: str,
+        param_name: str,
     ) -> str:
         """Strip a recognized unit suffix from a value string.
 
@@ -1164,7 +1211,10 @@ class TypecheckProvider:
 
     @staticmethod
     def _find_value_col(
-        lines: List[str], line_idx: int, param_name: str, value: str,
+        lines: List[str],
+        line_idx: int,
+        param_name: str,
+        value: str,
     ) -> int:
         """Find the column position of a parameter value on a line.
 

--- a/src/orca_lsp/parser.py
+++ b/src/orca_lsp/parser.py
@@ -4,7 +4,13 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from .keywords import BASIS_SETS, DFT_FUNCTIONALS, ELEMENTS, JOB_TYPES, WAVEFUNCTION_METHODS
+from .keywords import (
+    BASIS_SETS,
+    DFT_FUNCTIONALS,
+    ELEMENTS,
+    JOB_TYPES,
+    WAVEFUNCTION_METHODS,
+)
 from .validator import ORCAValidator
 
 # Pre-compiled regex patterns for performance (avoid recompilation on every loop)

--- a/src/orca_lsp/server.py
+++ b/src/orca_lsp/server.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, List, Optional
 
 from lsprotocol.types import (
     CodeAction,
-    CodeActionKind,
     CodeActionParams,
     CompletionItem,
     CompletionItemKind,
@@ -21,13 +20,10 @@ from lsprotocol.types import (
     Hover,
     HoverParams,
     Location,
-    MarkupContent,
-    MarkupKind,
     Position,
     Range,
     ReferenceParams,
     TextEdit,
-    WorkspaceEdit,
 )
 from pygls.server import LanguageServer
 
@@ -35,14 +31,6 @@ if TYPE_CHECKING:
     from pygls.workspace import TextDocument
 
 from . import __version__
-from .keywords import (
-    BASIS_SETS,
-    DFT_FUNCTIONALS,
-    ELEMENTS,
-    JOB_TYPES,
-    PERCENT_BLOCKS,
-    WAVEFUNCTION_METHODS,
-)
 from .features.code_actions import CodeActionProvider
 from .features.diagnostic import DiagnosticProvider
 from .features.formatting import FormattingProvider
@@ -53,6 +41,14 @@ from .features.navigation import (
     ReferencesProvider,
 )
 from .features.typecheck import TypecheckProvider
+from .keywords import (
+    BASIS_SETS,
+    DFT_FUNCTIONALS,
+    ELEMENTS,
+    JOB_TYPES,
+    PERCENT_BLOCKS,
+    WAVEFUNCTION_METHODS,
+)
 from .parser import ORCAParser
 
 # Pre-sorted elements for completions (avoid sorting on every request)
@@ -366,7 +362,8 @@ class ORCALanguageServer(LanguageServer):
 
         # Delegate to the CodeActionProvider
         actions = self.code_action_provider.get_code_actions(
-            source, params.context.diagnostics,
+            source,
+            params.context.diagnostics,
         )
 
         # Rewrite document URI into workspace edit changes (the provider uses
@@ -387,9 +384,7 @@ class ORCALanguageServer(LanguageServer):
         document = self.workspace.get_text_document(params.text_document.uri)
         return self.formatting_provider.format_document(document.source, params)
 
-    def _on_range_formatting(
-        self, params: DocumentRangeFormattingParams
-    ) -> List[TextEdit]:
+    def _on_range_formatting(self, params: DocumentRangeFormattingParams) -> List[TextEdit]:
         """Handle range formatting requests."""
         document = self.workspace.get_text_document(params.text_document.uri)
         return self.formatting_provider.format_range(document.source, params)


### PR DESCRIPTION
## Summary
- Run Black/isort on the CI-scoped ORCA files.
- Fix existing flake8 and mypy drift in src without touching fixture PR changes.
- Keep this cleanup separate from real-world fixture PR #55.

## Verification
- python3 -m black --check src tests/test_chemistry_validation.py tests/test_metadata.py
- uvx isort --check-only src tests/test_chemistry_validation.py tests/test_metadata.py
- uvx flake8 src tests/test_chemistry_validation.py tests/test_metadata.py --max-line-length=100 --extend-ignore=E501,E203
- uvx mypy src
- python3 -m pytest tests/