### PR TITLE
feat: implement ORCA RULE #62-#66

### DIFF
--- a/src/orca_lsp/features/lint.py
+++ b/src/orca_lsp/features/lint.py
@@ -23,6 +23,11 @@ ORCA-W002     Non-standard token in simple input                 Warning
 ORCA-W003     Duplicate token in simple input                    Warning
 ORCA-W004     %scf maxiter out of typical range                  Warning
 ORCA-W005     %pal nprocs unusually high                         Warning
+ORCA-W020     Missing method or basis set in route line          Warning
+ORCA-E020     Malformed %pal block (missing or invalid nprocs)  Error
+ORCA-E021     Missing charge/multiplicity in * xyz header        Error
+ORCA-E022     Coordinate block not terminated with * or end      Error
+ORCA-E023     Key block missing proper end terminator            Error
 ============  =================================================  ==========
 """
 
@@ -41,7 +46,10 @@ from lsprotocol.types import (
 
 from ..keywords import (
     ALL_KEYWORDS,
+    BASIS_SETS,
+    DFT_FUNCTIONALS,
     PERCENT_BLOCKS,
+    WAVEFUNCTION_METHODS,
 )
 from ..parser import ORCAParser, ParseResult, PercentBlock
 
@@ -62,6 +70,12 @@ RULE_NONSTANDARD_TOKEN = "ORCA-W002"
 RULE_DUPLICATE_TOKEN = "ORCA-W003"
 RULE_MAXITER_RANGE = "ORCA-W004"
 RULE_NPROCS_HIGH = "ORCA-W005"
+
+RULE_MISSING_METHOD_BASIS = "ORCA-W020"
+RULE_MALFORMED_PAL = "ORCA-E020"
+RULE_MISSING_XYZ_HEADER = "ORCA-E021"
+RULE_MISSING_COORD_TERMINATOR = "ORCA-E022"
+RULE_INVALID_BLOCK_TERMINATOR = "ORCA-E023"
 
 # Known tokens that are not in ALL_KEYWORDS but are valid ORCA simple-input
 # keywords (modifiers, convergence settings, solvent models, etc.).
@@ -161,6 +175,11 @@ class LintProvider:
         self._check_percent_blocks(result, lines, diagnostics)
         self._check_charge_multiplicity(result, lines, diagnostics)
         self._check_block_parameters(result, lines, diagnostics)
+        self._check_route_method_basis(result, lines, diagnostics)
+        self._check_pal_malformed(result, lines, diagnostics)
+        self._check_xyz_header(lines, diagnostics)
+        self._check_coord_terminator(lines, diagnostics)
+        self._check_block_terminator(lines, diagnostics)
 
         return diagnostics
 
@@ -622,6 +641,301 @@ class LintProvider:
                     code=RULE_MISSING_MAXCORE,
                 )
             )
+
+    # ------------------------------------------------------------------
+    # Route-line method/basis check (ORCA-W020)
+    # ------------------------------------------------------------------
+
+    def _check_route_method_basis(
+        self,
+        result: ParseResult,
+        lines: List[str],
+        diagnostics: List[Diagnostic],
+    ) -> None:
+        """Check route line for a method keyword and a basis-set keyword.
+
+        The route line is the first non-comment, non-empty line starting with
+        ``!``.  If it is missing a method (DFT functional, HF, MP2, etc.) or a
+        basis set, a warning is emitted.
+
+        Args:
+            result: Parsed result.
+            lines: Document lines.
+            diagnostics: Accumulator for diagnostics.
+        """
+        if result.simple_input is None:
+            return
+
+        si = result.simple_input
+        line_idx = si.line_number
+        if line_idx >= len(lines):
+            return
+
+        has_method = len(si.methods) > 0
+        has_basis = len(si.basis_sets) > 0
+
+        if has_method and has_basis:
+            return
+
+        raw_line = lines[line_idx]
+        col = raw_line.find("!")
+        if col < 0:
+            col = 0
+        end_col = len(raw_line.rstrip())
+
+        missing: List[str] = []
+        if not has_method:
+            missing.append("method")
+        if not has_basis:
+            missing.append("basis set")
+
+        diagnostics.append(
+            Diagnostic(
+                range=Range(
+                    start=Position(line=line_idx, character=col),
+                    end=Position(line=line_idx, character=end_col),
+                ),
+                message=(
+                    f"Route line missing {' and '.join(missing)} keyword"
+                ),
+                severity=DiagnosticSeverity.Warning,
+                source="orca-lsp-lint",
+                code=RULE_MISSING_METHOD_BASIS,
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Malformed %pal block (ORCA-E020)
+    # ------------------------------------------------------------------
+
+    def _check_pal_malformed(
+        self,
+        result: ParseResult,
+        lines: List[str],
+        diagnostics: List[Diagnostic],
+    ) -> None:
+        """Check that ``%pal`` blocks contain ``nprocs`` with a positive integer.
+
+        Args:
+            result: Parsed result.
+            lines: Document lines.
+            diagnostics: Accumulator for diagnostics.
+        """
+        for block in result.percent_blocks:
+            if block.name.lower() != "pal":
+                continue
+
+            nprocs = block.parameters.get("nprocs")
+            if nprocs is None or not isinstance(nprocs, int) or nprocs < 1:
+                col = self._block_name_col(lines, block.line_start)
+                diagnostics.append(
+                    Diagnostic(
+                        range=Range(
+                            start=Position(line=block.line_start, character=col),
+                            end=Position(
+                                line=block.line_start,
+                                character=col + len(block.name) + 1,
+                            ),
+                        ),
+                        message=(
+                            "%pal block must contain 'nprocs' with a positive integer"
+                        ),
+                        severity=DiagnosticSeverity.Error,
+                        source="orca-lsp-lint",
+                        code=RULE_MALFORMED_PAL,
+                    )
+                )
+
+    # ------------------------------------------------------------------
+    # Missing charge/multiplicity in * xyz header (ORCA-E021)
+    # ------------------------------------------------------------------
+
+    def _check_xyz_header(
+        self,
+        lines: List[str],
+        diagnostics: List[Diagnostic],
+    ) -> None:
+        """Check ``* xyz`` blocks for charge and multiplicity.
+
+        The header format must be ``* xyz <charge> <mult>``.  If either value
+        is missing, an error is emitted.
+
+        Args:
+            lines: Document lines.
+            diagnostics: Accumulator for diagnostics.
+        """
+        _xyz_re = re.compile(r"^\s*\*\s*xyz\b", re.IGNORECASE)
+        for i, line in enumerate(lines):
+            if not _xyz_re.match(line):
+                continue
+            parts = line.split()
+            # parts[0]="*", parts[1]="xyz", parts[2]=charge, parts[3]=mult
+            if len(parts) < 4:
+                col = line.find("*")
+                if col < 0:
+                    col = 0
+                end_col = len(line.rstrip())
+                if end_col <= col:
+                    end_col = col + 1
+                diagnostics.append(
+                    Diagnostic(
+                        range=Range(
+                            start=Position(line=i, character=col),
+                            end=Position(line=i, character=end_col),
+                        ),
+                        message="* xyz header missing charge and/or multiplicity",
+                        severity=DiagnosticSeverity.Error,
+                        source="orca-lsp-lint",
+                        code=RULE_MISSING_XYZ_HEADER,
+                    )
+                )
+
+    # ------------------------------------------------------------------
+    # Missing coordinate block terminator (ORCA-E022)
+    # ------------------------------------------------------------------
+
+    def _check_coord_terminator(
+        self,
+        lines: List[str],
+        diagnostics: List[Diagnostic],
+    ) -> None:
+        """Check that coordinate sections (``* xyz``) end with ``*`` or ``end``.
+
+        Args:
+            lines: Document lines.
+            diagnostics: Accumulator for diagnostics.
+        """
+        _xyz_re = re.compile(r"^\s*\*\s*xyz\b", re.IGNORECASE)
+        _star_re = re.compile(r"^\s*\*\s*$")
+        _end_re = re.compile(r"^\s*end\s*$", re.IGNORECASE)
+        _block_start_re = re.compile(r"^\s*%\s*\w+", re.IGNORECASE)
+
+        i = 0
+        while i < len(lines):
+            if not _xyz_re.match(lines[i]):
+                i += 1
+                continue
+
+            # Found a * xyz block.  Scan forward for terminator.
+            j = i + 1
+            found_terminator = False
+            while j < len(lines):
+                stripped = lines[j].strip()
+                # Bare * or * with only trailing whitespace terminates
+                if _star_re.match(lines[j]) or stripped.startswith("* "):
+                    found_terminator = True
+                    break
+                # "end" also terminates
+                if _end_re.match(lines[j]):
+                    found_terminator = True
+                    break
+                # Another % block or * xyz before terminator means we've
+                # gone past the section without finding one.
+                if _block_start_re.match(lines[j]) or _xyz_re.match(lines[j]):
+                    break
+                j += 1
+
+            if not found_terminator:
+                col = lines[i].find("*")
+                if col < 0:
+                    col = 0
+                end_col = len(lines[i].rstrip())
+                if end_col <= col:
+                    end_col = col + 1
+                diagnostics.append(
+                    Diagnostic(
+                        range=Range(
+                            start=Position(line=i, character=col),
+                            end=Position(line=i, character=end_col),
+                        ),
+                        message="Coordinate block not terminated with '*' or 'end'",
+                        severity=DiagnosticSeverity.Error,
+                        source="orca-lsp-lint",
+                        code=RULE_MISSING_COORD_TERMINATOR,
+                    )
+                )
+
+            i = j + 1 if found_terminator else i + 1
+
+    # ------------------------------------------------------------------
+    # Invalid key-block terminator (ORCA-E023)
+    # ------------------------------------------------------------------
+
+    def _check_block_terminator(
+        self,
+        lines: List[str],
+        diagnostics: List[Diagnostic],
+    ) -> None:
+        """Check that key blocks (``%xxx ...``) have a proper ``end`` terminator.
+
+        Multi-line blocks that are not single-line assignments must end with
+        ``end``.  This complements the existing unclosed-block check by
+        specifically validating the terminator syntax for known block types.
+
+        Args:
+            lines: Document lines.
+            diagnostics: Accumulator for diagnostics.
+        """
+        _block_start_re = re.compile(r"^\s*%\s*(\w+)", re.IGNORECASE)
+        _end_re = re.compile(r"\bend\b", re.IGNORECASE)
+
+        i = 0
+        while i < len(lines):
+            stripped = lines[i].strip()
+            match = _block_start_re.match(stripped)
+            if not match:
+                i += 1
+                continue
+
+            block_name = match.group(1).lower()
+
+            # Self-closing line (contains "end")
+            if _end_re.search(stripped):
+                i += 1
+                continue
+
+            # Single-line value block (e.g. %maxcore 4000)
+            parts = stripped.split()
+            if len(parts) == 2:
+                value = parts[1]
+                if value.isdigit() or (value.startswith('"') and value.endswith('"')):
+                    i += 1
+                    continue
+
+            # Multi-line block: scan for "end"
+            found_end = False
+            j = i + 1
+            while j < len(lines):
+                inner_stripped = lines[j].strip()
+                if _end_re.search(inner_stripped):
+                    found_end = True
+                    break
+                # Another block starts before end
+                inner_match = _block_start_re.match(inner_stripped)
+                if inner_match:
+                    inner_name = inner_match.group(1).lower()
+                    if inner_name in PERCENT_BLOCKS or inner_name == block_name:
+                        break
+                j += 1
+
+            if not found_end:
+                col = lines[i].find("%")
+                if col < 0:
+                    col = 0
+                diagnostics.append(
+                    Diagnostic(
+                        range=Range(
+                            start=Position(line=i, character=col),
+                            end=Position(line=i, character=col + len(block_name) + 1),
+                        ),
+                        message=f"Key block '%{block_name}' missing 'end' terminator",
+                        severity=DiagnosticSeverity.Error,
+                        source="orca-lsp-lint",
+                        code=RULE_INVALID_BLOCK_TERMINATOR,
+                    )
+                )
+
+            i = j + 1 if found_end else i + 1
 
     # ------------------------------------------------------------------
     # Snapshot helpers

--- a/tests/features/test_lint.py
+++ b/tests/features/test_lint.py
@@ -9,9 +9,14 @@ from orca_lsp.features.lint import (
     RULE_CHARGE_MULTIPLICITY,
     RULE_DUPLICATE_BLOCK,
     RULE_DUPLICATE_TOKEN,
+    RULE_INVALID_BLOCK_TERMINATOR,
     RULE_INVALID_MULTIPLICITY,
+    RULE_MALFORMED_PAL,
     RULE_MAXITER_RANGE,
+    RULE_MISSING_COORD_TERMINATOR,
     RULE_MISSING_MAXCORE,
+    RULE_MISSING_METHOD_BASIS,
+    RULE_MISSING_XYZ_HEADER,
     RULE_NPROCS_HIGH,
     RULE_UNCLOSED_BLOCK,
     RULE_UNKNOWN_BLOCK,
@@ -626,3 +631,272 @@ class TestEdgeCases:
         diagnostics = provider.lint(text)
         codes = [d.code for d in diagnostics]
         assert RULE_UNKNOWN_TOKEN not in codes
+
+
+# ---------------------------------------------------------------------------
+# Missing method / basis in route line (ORCA-W020)
+# ---------------------------------------------------------------------------
+
+
+class TestMissingMethodBasis:
+    """Tests for missing method or basis set in the route line."""
+
+    def test_missing_method_detected(self, provider: LintProvider) -> None:
+        """Route line with only basis set but no method produces ORCA-W020."""
+        text = "! def2-TZVP SP\n%maxcore 4000\n* xyz 0 1\n  H 0 0 0\n*\n"
+        diagnostics = provider.lint(text)
+        codes = [d.code for d in diagnostics]
+        assert RULE_MISSING_METHOD_BASIS in codes, (
+            f"Expected {RULE_MISSING_METHOD_BASIS}, got codes: {codes}"
+        )
+
+    def test_missing_basis_detected(self, provider: LintProvider) -> None:
+        """Route line with only method but no basis set produces ORCA-W020."""
+        text = "! B3LYP SP\n%maxcore 4000\n* xyz 0 1\n  H 0 0 0\n*\n"
+        diagnostics = provider.lint(text)
+        codes = [d.code for d in diagnostics]
+        assert RULE_MISSING_METHOD_BASIS in codes
+
+    def test_missing_both_detected(self, provider: LintProvider) -> None:
+        """Route line with neither method nor basis set produces ORCA-W020."""
+        text = "! SP\n%maxcore 4000\n* xyz 0 1\n  H 0 0 0\n*\n"
+        diagnostics = provider.lint(text)
+        codes = [d.code for d in diagnostics]
+        assert RULE_MISSING_METHOD_BASIS in codes
+
+    def test_has_both_no_warning(self, provider: LintProvider) -> None:
+        """Route line with method and basis set produces no ORCA-W020."""
+        text = "! B3LYP def2-TZVP SP\n%maxcore 4000\n* xyz 0 1\n  H 0 0 0\n*\n"
+        diagnostics = provider.lint(text)
+        codes = [d.code for d in diagnostics]
+        assert RULE_MISSING_METHOD_BASIS not in codes
+
+    def test_missing_method_basis_severity_warning(self, provider: LintProvider) -> None:
+        """Missing method/basis diagnostic has Warning severity."""
+        from lsprotocol.types import DiagnosticSeverity
+
+        text = "! def2-TZVP SP\n%maxcore 4000\n* xyz 0 1\n  H 0 0 0\n*\n"
+        diagnostics = provider.lint(text)
+        for d in diagnostics:
+            if d.code == RULE_MISSING_METHOD_BASIS:
+                assert d.severity == DiagnosticSeverity.Warning
+                return
+        pytest.fail("No ORCA-W020 diagnostic found")
+
+
+# ---------------------------------------------------------------------------
+# Malformed %pal block (ORCA-E020)
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedPal:
+    """Tests for malformed %pal blocks."""
+
+    def test_pal_missing_nprocs(self, provider: LintProvider) -> None:
+        """%pal block without nprocs produces ORCA-E020."""
+        text = (
+            "! B3LYP def2-TZVP SP\n"
+            "%pal\n"
+            "end\n"
+            "* xyz 0 1\n"
+            "  H 0 0 0\n"
+            "*\n"
+        )
+        diagnostics = provider.lint(text)
+        codes = [d.code for d in diagnostics]
+        assert RULE_MALFORMED_PAL in codes, (
+            f"Expected {RULE_MALFORMED_PAL}, got codes: {codes}"
+        )
+
+    def test_pal_nprocs_zero(self, provider: LintProvider) -> None:
+        """%pal with nprocs 0 produces ORCA-E020."""
+        text = (
+            "! B3LYP def2-TZVP SP\n"
+            "%pal nprocs 0 end\n"
+            "* xyz 0 1\n"
+            "  H 0 0 0\n"
+            "*\n"
+        )
+        diagnostics = provider.lint(text)
+        codes = [d.code for d in diagnostics]
+        assert RULE_MALFORMED_PAL in codes
+
+    def test_pal_nprocs_negative(self, provider: LintProvider) -> None:
+        """%pal with negative nprocs produces ORCA-E020."""
+        text = (
+            "! B3LYP def2-TZVP SP\n"
+            "%pal nprocs -2 end\n"
+            "* xyz 0 1\n"
+            "  H 0 0 0\n"
+            "*\n"
+        )
+        diagnostics = provider.lint(text)
+        codes = [d.code for d in diagnostics]
+        assert RULE_MALFORMED_PAL in codes
+
+    def test_pal_valid_nprocs_no_error(self, provider: LintProvider) -> None:
+        """%pal with valid nprocs produces no ORCA-E020."""
+        text = (
+            "! B3LYP def2-TZVP SP\n"
+            "%pal nprocs 4 end\n"
+            "* xyz 0 1\n"
+            "  H 0 0 0\n"
+            "*\n"
+        )
+        diagnostics = provider.lint(text)
+        codes = [d.code for d in diagnostics]
+        assert RULE_MALFORMED_PAL not in codes
+
+    def test_malformed_pal_severity_error(self, provider: LintProvider) -> None:
+        """Malformed %pal diagnostic has Error severity."""
+        from lsprotocol.types import DiagnosticSeverity
+
+        text = "! B3LYP def2-TZVP SP\n%pal\nend\n* xyz 0 1\n  H 0 0 0\n*\n"
+        diagnostics = provider.lint(text)
+        for d in diagnostics:
+            if d.code == RULE_MALFORMED_PAL:
+                assert d.severity == DiagnosticSeverity.Error
+                return
+        pytest.fail("No ORCA-E020 diagnostic found")
+
+
+# ---------------------------------------------------------------------------
+# Missing charge/multiplicity in * xyz header (ORCA-E021)
+# ---------------------------------------------------------------------------
+
+
+class TestMissingXyzHeader:
+    """Tests for missing charge/multiplicity in * xyz header."""
+
+    def test_missing_charge_mult(self, provider: LintProvider) -> None:
+        """* xyz without charge and multiplicity produces ORCA-E021."""
+        text = "! B3LYP def2-TZVP SP\n%maxcore 4000\n* xyz\n  H 0 0 0\n*\n"
+        diagnostics = provider.lint(text)
+        codes = [d.code for d in diagnostics]
+        assert RULE_MISSING_XYZ_HEADER in codes, (
+            f"Expected {RULE_MISSING_XYZ_HEADER}, got codes: {codes}"
+        )
+
+    def test_valid_xyz_header_no_error(self, provider: LintProvider) -> None:
+        """* xyz 0 1 with both values produces no ORCA-E021."""
+        text = "! B3LYP def2-TZVP SP\n%maxcore 4000\n* xyz 0 1\n  H 0 0 0\n*\n"
+        diagnostics = provider.lint(text)
+        codes = [d.code for d in diagnostics]
+        assert RULE_MISSING_XYZ_HEADER not in codes
+
+    def test_missing_xyz_header_severity_error(self, provider: LintProvider) -> None:
+        """Missing xyz header diagnostic has Error severity."""
+        from lsprotocol.types import DiagnosticSeverity
+
+        text = "! B3LYP def2-TZVP SP\n%maxcore 4000\n* xyz\n  H 0 0 0\n*\n"
+        diagnostics = provider.lint(text)
+        for d in diagnostics:
+            if d.code == RULE_MISSING_XYZ_HEADER:
+                assert d.severity == DiagnosticSeverity.Error
+                return
+        pytest.fail("No ORCA-E021 diagnostic found")
+
+
+# ---------------------------------------------------------------------------
+# Missing coordinate block terminator (ORCA-E022)
+# ---------------------------------------------------------------------------
+
+
+class TestMissingCoordTerminator:
+    """Tests for coordinate blocks not terminated with * or end."""
+
+    def test_missing_terminator(self, provider: LintProvider) -> None:
+        """* xyz block without closing * produces ORCA-E022."""
+        text = "! B3LYP def2-TZVP SP\n%maxcore 4000\n* xyz 0 1\n  H 0 0 0\n"
+        diagnostics = provider.lint(text)
+        codes = [d.code for d in diagnostics]
+        assert RULE_MISSING_COORD_TERMINATOR in codes, (
+            f"Expected {RULE_MISSING_COORD_TERMINATOR}, got codes: {codes}"
+        )
+
+    def test_properly_terminated_no_error(self, provider: LintProvider) -> None:
+        """* xyz block with closing * produces no ORCA-E022."""
+        text = "! B3LYP def2-TZVP SP\n%maxcore 4000\n* xyz 0 1\n  H 0 0 0\n*\n"
+        diagnostics = provider.lint(text)
+        codes = [d.code for d in diagnostics]
+        assert RULE_MISSING_COORD_TERMINATOR not in codes
+
+    def test_terminated_with_end(self, provider: LintProvider) -> None:
+        """* xyz block terminated with 'end' produces no ORCA-E022."""
+        text = "! B3LYP def2-TZVP SP\n%maxcore 4000\n* xyz 0 1\n  H 0 0 0\nend\n"
+        diagnostics = provider.lint(text)
+        codes = [d.code for d in diagnostics]
+        assert RULE_MISSING_COORD_TERMINATOR not in codes
+
+    def test_missing_coord_terminator_severity_error(self, provider: LintProvider) -> None:
+        """Missing coord terminator diagnostic has Error severity."""
+        from lsprotocol.types import DiagnosticSeverity
+
+        text = "! B3LYP def2-TZVP SP\n%maxcore 4000\n* xyz 0 1\n  H 0 0 0\n"
+        diagnostics = provider.lint(text)
+        for d in diagnostics:
+            if d.code == RULE_MISSING_COORD_TERMINATOR:
+                assert d.severity == DiagnosticSeverity.Error
+                return
+        pytest.fail("No ORCA-E022 diagnostic found")
+
+
+# ---------------------------------------------------------------------------
+# Invalid key-block terminator (ORCA-E023)
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidBlockTerminator:
+    """Tests for key blocks missing proper 'end' terminator."""
+
+    def test_scf_missing_end(self, provider: LintProvider) -> None:
+        """%scf block without 'end' produces ORCA-E023."""
+        text = (
+            "! B3LYP def2-TZVP SP\n"
+            "%scf\n"
+            "  maxiter 100\n"
+            "%maxcore 4000\n"
+            "* xyz 0 1\n"
+            "  H 0 0 0\n"
+            "*\n"
+        )
+        diagnostics = provider.lint(text)
+        codes = [d.code for d in diagnostics]
+        assert RULE_INVALID_BLOCK_TERMINATOR in codes, (
+            f"Expected {RULE_INVALID_BLOCK_TERMINATOR}, got codes: {codes}"
+        )
+
+    def test_scf_with_end_no_error(self, provider: LintProvider) -> None:
+        """%scf block with 'end' produces no ORCA-E023."""
+        text = (
+            "! B3LYP def2-TZVP SP\n"
+            "%scf\n"
+            "  maxiter 100\n"
+            "end\n"
+            "%maxcore 4000\n"
+            "* xyz 0 1\n"
+            "  H 0 0 0\n"
+            "*\n"
+        )
+        diagnostics = provider.lint(text)
+        codes = [d.code for d in diagnostics]
+        assert RULE_INVALID_BLOCK_TERMINATOR not in codes
+
+    def test_single_line_value_no_error(self, provider: LintProvider) -> None:
+        """Single-line %maxcore 4000 is not flagged as missing terminator."""
+        text = "! B3LYP def2-TZVP SP\n%maxcore 4000\n* xyz 0 1\n  H 0 0 0\n*\n"
+        diagnostics = provider.lint(text)
+        codes = [d.code for d in diagnostics]
+        assert RULE_INVALID_BLOCK_TERMINATOR not in codes
+
+    def test_invalid_block_terminator_severity_error(self, provider: LintProvider) -> None:
+        """Invalid block terminator diagnostic has Error severity."""
+        from lsprotocol.types import DiagnosticSeverity
+
+        text = "! B3LYP def2-TZVP SP\n%scf\n  maxiter 100\n%maxcore 4000\n* xyz 0 1\n  H 0 0 0\n*\n"
+        diagnostics = provider.lint(text)
+        for d in diagnostics:
+            if d.code == RULE_INVALID_BLOCK_TERMINATOR:
+                assert d.severity == DiagnosticSeverity.Error
+                return
+        pytest.fail("No ORCA-E023 diagnostic found")

--- a/tests/fixtures/rules/invalid_block_terminator.json
+++ b/tests/fixtures/rules/invalid_block_terminator.json
@@ -1,0 +1,53 @@
+[
+  {
+    "code": "ORCA-E003",
+    "message": "Unclosed % block: '%scf'",
+    "range": {
+      "end": {
+        "character": 4,
+        "line": 1
+      },
+      "start": {
+        "character": 0,
+        "line": 1
+      }
+    },
+    "severity": 1,
+    "severity_label": "error",
+    "source": "orca-lsp-lint"
+  },
+  {
+    "code": "ORCA-E023",
+    "message": "Key block '%scf' missing 'end' terminator",
+    "range": {
+      "end": {
+        "character": 4,
+        "line": 1
+      },
+      "start": {
+        "character": 0,
+        "line": 1
+      }
+    },
+    "severity": 1,
+    "severity_label": "error",
+    "source": "orca-lsp-lint"
+  },
+  {
+    "code": "ORCA-E007",
+    "message": "Multiplicity 1 inconsistent with 1 electrons (charge 0)",
+    "range": {
+      "end": {
+        "character": 9,
+        "line": 4
+      },
+      "start": {
+        "character": 8,
+        "line": 4
+      }
+    },
+    "severity": 1,
+    "severity_label": "error",
+    "source": "orca-lsp-lint"
+  }
+]

--- a/tests/fixtures/rules/malformed_pal.json
+++ b/tests/fixtures/rules/malformed_pal.json
@@ -1,0 +1,36 @@
+[
+  {
+    "code": "ORCA-E020",
+    "message": "%pal block must contain 'nprocs' with a positive integer",
+    "range": {
+      "end": {
+        "character": 4,
+        "line": 1
+      },
+      "start": {
+        "character": 0,
+        "line": 1
+      }
+    },
+    "severity": 1,
+    "severity_label": "error",
+    "source": "orca-lsp-lint"
+  },
+  {
+    "code": "ORCA-E007",
+    "message": "Multiplicity 1 inconsistent with 1 electrons (charge 0)",
+    "range": {
+      "end": {
+        "character": 9,
+        "line": 3
+      },
+      "start": {
+        "character": 8,
+        "line": 3
+      }
+    },
+    "severity": 1,
+    "severity_label": "error",
+    "source": "orca-lsp-lint"
+  }
+]

--- a/tests/fixtures/rules/missing_coord_terminator.json
+++ b/tests/fixtures/rules/missing_coord_terminator.json
@@ -1,0 +1,36 @@
+[
+  {
+    "code": "ORCA-E022",
+    "message": "Coordinate block not terminated with '*' or 'end'",
+    "range": {
+      "end": {
+        "character": 9,
+        "line": 2
+      },
+      "start": {
+        "character": 0,
+        "line": 2
+      }
+    },
+    "severity": 1,
+    "severity_label": "error",
+    "source": "orca-lsp-lint"
+  },
+  {
+    "code": "ORCA-E007",
+    "message": "Multiplicity 1 inconsistent with 1 electrons (charge 0)",
+    "range": {
+      "end": {
+        "character": 9,
+        "line": 2
+      },
+      "start": {
+        "character": 8,
+        "line": 2
+      }
+    },
+    "severity": 1,
+    "severity_label": "error",
+    "source": "orca-lsp-lint"
+  }
+]

--- a/tests/fixtures/rules/missing_method_basis.json
+++ b/tests/fixtures/rules/missing_method_basis.json
@@ -1,0 +1,36 @@
+[
+  {
+    "code": "ORCA-W020",
+    "message": "Route line missing method keyword",
+    "range": {
+      "end": {
+        "character": 14,
+        "line": 0
+      },
+      "start": {
+        "character": 0,
+        "line": 0
+      }
+    },
+    "severity": 2,
+    "severity_label": "warning",
+    "source": "orca-lsp-lint"
+  },
+  {
+    "code": "ORCA-E007",
+    "message": "Multiplicity 1 inconsistent with 1 electrons (charge 0)",
+    "range": {
+      "end": {
+        "character": 9,
+        "line": 2
+      },
+      "start": {
+        "character": 8,
+        "line": 2
+      }
+    },
+    "severity": 1,
+    "severity_label": "error",
+    "source": "orca-lsp-lint"
+  }
+]

--- a/tests/fixtures/rules/missing_xyz_header.json
+++ b/tests/fixtures/rules/missing_xyz_header.json
@@ -1,0 +1,36 @@
+[
+  {
+    "code": "ORCA-E007",
+    "message": "Multiplicity 1 inconsistent with 1 electrons (charge 0)",
+    "range": {
+      "end": {
+        "character": 1,
+        "line": 2
+      },
+      "start": {
+        "character": 0,
+        "line": 2
+      }
+    },
+    "severity": 1,
+    "severity_label": "error",
+    "source": "orca-lsp-lint"
+  },
+  {
+    "code": "ORCA-E021",
+    "message": "* xyz header missing charge and/or multiplicity",
+    "range": {
+      "end": {
+        "character": 5,
+        "line": 2
+      },
+      "start": {
+        "character": 0,
+        "line": 2
+      }
+    },
+    "severity": 1,
+    "severity_label": "error",
+    "source": "orca-lsp-lint"
+  }
+]


### PR DESCRIPTION
Implements 5 ORCA diagnostic rules with tests and golden fixtures:

**ORCA-W020 - orca.route.missing_method_basis**: Warns when the route line (first `!` line) is missing a method keyword (B3LYP, HF, MP2, etc.) or a basis set keyword (def2-SVP, def2-TZVP, cc-pVDZ, etc.).

**ORCA-E020 - orca.pal.malformed_block**: Errors when a `%pal` block is missing `nprocs` or has a non-positive integer value.

**ORCA-E021 - orca.coords.missing_xyz_header**: Errors when a `* xyz` block is missing charge and/or multiplicity after `xyz`.

**ORCA-E022 - orca.coords.missing_terminator**: Errors when a coordinate section (`* xyz`) is not terminated with `*` or `end`.

**ORCA-E023 - orca.block.invalid_terminator**: Errors when a key block (`%scf`, `%pal`, etc.) is missing its `end` terminator.

Fixes #62 Fixes #63 Fixes #64 Fixes #65 Fixes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)