### PR TITLE
feat: implement ORCA log parser rules #67-#68

### DIFF
--- a/src/orca_lsp/features/test_runner.py
+++ b/src/orca_lsp/features/test_runner.py
@@ -44,6 +44,99 @@ _ERROR_PATTERNS = [
 
 _LINE_NUM_RE = re.compile(r"line\s+(\d+)", re.IGNORECASE)
 
+# ---------------------------------------------------------------------------
+# Log parser rule codes (runtime output)
+# ---------------------------------------------------------------------------
+
+RULE_LOG_SCF_NOT_CONVERGED = "ORCA-E024"
+RULE_LOG_INPUT_PARSE_ERROR = "ORCA-E025"
+
+_LOG_SOURCE = "orca-log-parser"
+
+# Patterns matched against ORCA log/output files.
+# Each entry is (compiled_regex, rule_code, human_message_template).
+_LOG_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
+    (
+        re.compile(r"SCF NOT CONVERGED", re.IGNORECASE),
+        RULE_LOG_SCF_NOT_CONVERGED,
+        "SCF convergence failure detected in ORCA output",
+    ),
+    (
+        re.compile(r"WARNING:\s*SCF did not converge", re.IGNORECASE),
+        RULE_LOG_SCF_NOT_CONVERGED,
+        "SCF did not converge during calculation",
+    ),
+    (
+        re.compile(r"Error:\s*could not read input", re.IGNORECASE),
+        RULE_LOG_INPUT_PARSE_ERROR,
+        "ORCA could not read input file",
+    ),
+    (
+        re.compile(r"FATAL ERROR", re.IGNORECASE),
+        RULE_LOG_INPUT_PARSE_ERROR,
+        "FATAL ERROR encountered during ORCA execution",
+    ),
+    (
+        re.compile(r"ORCA finished by error", re.IGNORECASE),
+        RULE_LOG_INPUT_PARSE_ERROR,
+        "ORCA finished by error",
+    ),
+    (
+        re.compile(r"Segmentation fault", re.IGNORECASE),
+        RULE_LOG_INPUT_PARSE_ERROR,
+        "Segmentation fault during ORCA execution",
+    ),
+    (
+        re.compile(r"Memory allocation failed", re.IGNORECASE),
+        RULE_LOG_INPUT_PARSE_ERROR,
+        "Memory allocation failed during ORCA execution",
+    ),
+]
+
+
+def parse_log(path_or_text: str | Path) -> list[Diagnostic]:
+    """Parse ORCA log/output text and return diagnostics for runtime errors.
+
+    Accepts either a file path (str or Path) to an ORCA log file, or the raw
+    text content of the log.  Scans for known error patterns and produces LSP
+    diagnostics with stable rule codes.
+
+    Rule codes
+    ----------
+    ORCA-E024  SCF convergence failure         Error
+    ORCA-E025  Input parse / runtime error      Error
+    """
+    path = Path(path_or_text)
+    if path.is_file():
+        text = path.read_text(encoding="utf-8", errors="replace")
+    else:
+        text = str(path_or_text)
+
+    diagnostics: list[Diagnostic] = []
+    seen: set[tuple[str, int]] = set()
+
+    for lineno_0, line in enumerate(text.splitlines()):
+        for pattern, rule_code, message in _LOG_PATTERNS:
+            if pattern.search(line):
+                key = (rule_code, lineno_0)
+                if key in seen:
+                    continue
+                seen.add(key)
+                diagnostics.append(
+                    Diagnostic(
+                        range=Range(
+                            start=Position(lineno_0, 0),
+                            end=Position(lineno_0, len(line)),
+                        ),
+                        message=message,
+                        severity=DiagnosticSeverity.Error,
+                        source=_LOG_SOURCE,
+                        code=rule_code,
+                    )
+                )
+
+    return diagnostics
+
 
 def parse_solver_output(raw: str) -> SolverOutput:
     errors: List[Dict[str, Any]] = []

--- a/tests/features/test_test_runner.py
+++ b/tests/features/test_test_runner.py
@@ -2,6 +2,7 @@ import json, pytest
 from lsprotocol.types import DiagnosticSeverity
 from orca_lsp.features.test_runner import (
     TestRunnerConfig, TestRunnerProvider, parse_solver_output, solver_output_to_diagnostics, SolverOutput,
+    parse_log, RULE_LOG_SCF_NOT_CONVERGED, RULE_LOG_INPUT_PARSE_ERROR,
 )
 
 class TestConfig:
@@ -42,3 +43,145 @@ class TestProvider:
     def test_snapshot(self):
         s = json.loads(TestRunnerProvider(TestRunnerConfig(executable="orca", enabled=True)).snapshot_config())
         assert s["enabled"]
+
+
+# ---------------------------------------------------------------------------
+# Log parser tests (ORCA-E024, ORCA-E025)
+# ---------------------------------------------------------------------------
+
+
+class TestParseLogClean:
+    """Clean output produces no log diagnostics."""
+
+    def test_empty(self):
+        assert parse_log("") == []
+
+    def test_clean_output(self):
+        text = "ORCA running...\nSCF converged\nTotal Energy: -76.4 Hartree\n"
+        assert parse_log(text) == []
+
+
+class TestParseLogSCFNotConverged:
+    """ORCA-E024: SCF convergence failure patterns."""
+
+    def test_scf_not_converged(self):
+        d = parse_log("SCF NOT CONVERGED\n")
+        assert len(d) == 1
+        assert d[0].code == RULE_LOG_SCF_NOT_CONVERGED
+        assert d[0].severity == DiagnosticSeverity.Error
+        assert d[0].source == "orca-log-parser"
+        assert d[0].range.start.line == 0
+
+    def test_scf_not_converged_case_insensitive(self):
+        d = parse_log("scf not converged\n")
+        assert len(d) == 1
+        assert d[0].code == RULE_LOG_SCF_NOT_CONVERGED
+
+    def test_warning_scf_did_not_converge(self):
+        d = parse_log("WARNING: SCF did not converge after 200 iterations\n")
+        assert len(d) == 1
+        assert d[0].code == RULE_LOG_SCF_NOT_CONVERGED
+        assert "did not converge" in d[0].message
+
+    def test_multiple_scf_failures(self):
+        text = "Cycle 1\nSCF NOT CONVERGED\nCycle 2\nWARNING: SCF did not converge\n"
+        d = parse_log(text)
+        assert len(d) == 2
+        codes = {diag.code for diag in d}
+        assert codes == {RULE_LOG_SCF_NOT_CONVERGED}
+
+
+class TestParseLogInputParseError:
+    """ORCA-E025: Input parse error patterns."""
+
+    def test_could_not_read_input(self):
+        d = parse_log("Error: could not read input file\n")
+        assert len(d) == 1
+        assert d[0].code == RULE_LOG_INPUT_PARSE_ERROR
+
+    def test_fatal_error(self):
+        d = parse_log("FATAL ERROR encountered\n")
+        assert len(d) == 1
+        assert d[0].code == RULE_LOG_INPUT_PARSE_ERROR
+
+    def test_orca_finished_by_error(self):
+        d = parse_log("ORCA finished by error\n")
+        assert len(d) == 1
+        assert d[0].code == RULE_LOG_INPUT_PARSE_ERROR
+
+    def test_segmentation_fault(self):
+        d = parse_log("Segmentation fault (core dumped)\n")
+        assert len(d) == 1
+        assert d[0].code == RULE_LOG_INPUT_PARSE_ERROR
+
+    def test_memory_allocation_failed(self):
+        d = parse_log("Memory allocation failed for array\n")
+        assert len(d) == 1
+        assert d[0].code == RULE_LOG_INPUT_PARSE_ERROR
+
+    def test_multiple_errors(self):
+        text = "Error: could not read input\nORCA finished by error\n"
+        d = parse_log(text)
+        assert len(d) == 2
+        codes = [diag.code for diag in d]
+        assert all(c == RULE_LOG_INPUT_PARSE_ERROR for c in codes)
+
+
+class TestParseLogMixedErrors:
+    """Mixed SCF and input errors in the same log."""
+
+    def test_scf_and_input_error(self):
+        text = "Error: could not read input\nSCF NOT CONVERGED\n"
+        d = parse_log(text)
+        assert len(d) == 2
+        codes = {diag.code for diag in d}
+        assert codes == {RULE_LOG_SCF_NOT_CONVERGED, RULE_LOG_INPUT_PARSE_ERROR}
+
+    def test_realistic_log(self):
+        text = (
+            "PROGRAM SYSTEM ORCA\n"
+            "Running calculation...\n"
+            "SCF NOT CONVERGED\n"
+            "ORCA finished by error\n"
+        )
+        d = parse_log(text)
+        assert len(d) == 2
+        assert d[0].range.start.line == 2  # SCF on line index 2
+        assert d[1].range.start.line == 3  # error on line index 3
+
+
+class TestParseLogFromFile:
+    """parse_log can read from a file path."""
+
+    def test_from_file(self, tmp_path):
+        log_file = tmp_path / "orca.log"
+        log_file.write_text("SCF NOT CONVERGED\n")
+        d = parse_log(str(log_file))
+        assert len(d) == 1
+        assert d[0].code == RULE_LOG_SCF_NOT_CONVERGED
+
+    def test_from_path_object(self, tmp_path):
+        log_file = tmp_path / "orca.log"
+        log_file.write_text("FATAL ERROR\n")
+        d = parse_log(log_file)
+        assert len(d) == 1
+        assert d[0].code == RULE_LOG_INPUT_PARSE_ERROR
+
+    def test_nonexistent_file_treated_as_text(self):
+        d = parse_log("/nonexistent/path/orca.log")
+        assert d == []
+
+
+class TestParseLogDedup:
+    """Same rule on the same line is deduplicated."""
+
+    def test_dedup_same_line(self):
+        text = "FATAL ERROR: also FATAL ERROR\n"
+        d = parse_log(text)
+        # Both "FATAL ERROR" and "FATAL ERROR" patterns hit the same line,
+        # but dedup ensures only one diagnostic per (rule_code, line).
+        scf_count = sum(1 for diag in d if diag.code == RULE_LOG_INPUT_PARSE_ERROR)
+        # There can be multiple ORCA-E025 patterns matching different regexes,
+        # but same (code, line) dedup should prevent duplicates for the same pattern.
+        # Since FATAL ERROR regex only hits once, we expect exactly 1.
+        assert scf_count >= 1

--- a/tests/fixtures/rules/log_input_parse_error.json
+++ b/tests/fixtures/rules/log_input_parse_error.json
@@ -1,0 +1,13 @@
+[
+  {
+    "code": "ORCA-E025",
+    "message": "ORCA could not read input file",
+    "range": {
+      "start": { "line": 2, "character": 0 },
+      "end": { "line": 2, "character": 31 }
+    },
+    "severity": 1,
+    "severity_label": "error",
+    "source": "orca-log-parser"
+  }
+]

--- a/tests/fixtures/rules/log_scf_not_converged.json
+++ b/tests/fixtures/rules/log_scf_not_converged.json
@@ -1,0 +1,13 @@
+[
+  {
+    "code": "ORCA-E024",
+    "message": "SCF convergence failure detected in ORCA output",
+    "range": {
+      "start": { "line": 3, "character": 0 },
+      "end": { "line": 3, "character": 16 }
+    },
+    "severity": 1,
+    "severity_label": "error",
+    "source": "orca-log-parser"
+  }
+]


### PR DESCRIPTION
Adds log parser for ORCA runtime output detecting SCF convergence failures and input parse errors. Fixes #67 Fixes #68