### PR TITLE
feat: expand ORCA documentation collection and wiki digest

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,10 +4,18 @@
 
 欢迎使用ORCA-LSP知识库，这是一个基于Karpathy风格的LLM维护的wiki，专注于ORCA量子化学软件的Language Server Protocol实现。
 
-## 📁 导航结构 / Navigation Structure
+## 导航结构 / Navigation Structure
 
 ### 原始资料 / Raw Sources
 - **raw/assets/**: 源文件、文档、示例的原始副本
+  - `orca-input-format.md` -- ORCA输入文件格式官方文档
+  - `orca-keywords-reference.md` -- ORCA关键字完整参考
+  - `orca-examples.md` -- 18个ORCA输入文件示例
+  - `orca-output-format.md` -- ORCA输出文件格式参考
+  - `orca-compound-jobs.md` -- 复合作业与工作流文档
+  - `orca-basis-sets-reference.md` -- ORCA基组完整参考
+  - `orca-github-tools.md` -- GitHub ORCA工具与解析器
+  - `orca-tutorials.md` -- ORCA教程与学习资源
 
 ### 知识库 / Wiki
 
@@ -26,6 +34,8 @@ ORCA特定的概念、方法和数据结构：
 - [[Language_Server_Protocol]] - LSP服务器实现
 - [[Diagnostic_Engine_v1]] - 诊断引擎v1规范
 - [[OpenQC_Alignment]] - OpenQC对齐规范
+- [[ORCA_Official_Documentation]] - ORCA官方文档资源汇总
+- [[ORCA_GitHub_Tools]] - ORCA相关工具与解析器
 
 #### 概念页面 / Concepts (wiki/concepts/)
 跨领域的量子化学概念：
@@ -40,6 +50,7 @@ ORCA特定的概念、方法和数据结构：
 - [[Dispersion_Corrections]] - 色散校正（D3/D3BJ/D4）
 - [[Frequency_Calculation]] - 频率计算
 - [[Geometry_Optimization]] - 几何优化
+- [[Compound_Jobs]] - 复合作业与工作流
 
 #### 综合页面 / Synthesis (wiki/synthesis/)
 API参考、诊断目录、使用指南：
@@ -47,39 +58,46 @@ API参考、诊断目录、使用指南：
 - [[ORCA_LSP_API_Reference]] - ORCA-LSP API参考
 - [[Diagnostics_Catalog]] - 诊断目录
 - [[Input_File_Guide]] - 输入文件指南
+- [[ORCA_Output_Guide]] - ORCA输出文件解析指南
 
-## 🎯 快速开始 / Quick Start
+## 快速开始 / Quick Start
 
 1. **新手入门**：从 [[ORCA_Quantum_Chemistry]] 开始了解ORCA
 2. **学习语法**：阅读 [[Input_File_Guide]] 掌握输入文件格式
 3. **选择方法**：参考 [[DFT_Functionals]] 和 [[Basis_Set_Selection]]
 4. **设置计算**：查看 [[Job_Types]] 和 [[Percent_Blocks]]
 5. **理解诊断**：浏览 [[Diagnostics_Catalog]] 了解错误处理
+6. **多步工作流**：参考 [[Compound_Jobs]] 了解复合作业
+7. **解析输出**：查看 [[ORCA_Output_Guide]] 了解输出文件
 
-## 📊 统计信息 / Statistics
+## 统计信息 / Statistics
 
-- **实体页面**：12
-- **概念页面**：10
-- **综合页面**：3
-- **总Wiki文件**：25
-- **原始资料文件**：10+
+- **实体页面**：14
+- **概念页面**：11
+- **综合页面**：4
+- **总Wiki文件**：29
+- **原始资料文件**：18+
 
-## 🔍 搜索建议 / Search Tips
+## 搜索建议 / Search Tips
 
 - 查找特定泛函：搜索"B3LYP"、"PBE0"等
 - 查找基组：搜索"def2-"、"cc-pVXZ"等
 - 查找计算类型：搜索"OPT"、"FREQ"、"TS"等
 - 查找%块：搜索"%maxcore"、"%tddft"等
+- 查找输出格式：搜索"FINAL SINGLE POINT ENERGY"等
 
-## 📝 更新日志 / Change Log
+## 更新日志 / Change Log
 
 参见 [[log.md]] 了解知识库的详细变更历史。
 
-## 🔗 外部链接 / External Links
+## 外部链接 / External Links
 
-- ORCA官方文档：https://sites.cecs.anu.edu.au/orca/
-- ORCA-LSP GitHub：https://github.com/newtontech/orca-lsp
-- OpenQC-VSCode：https://github.com/newtontech/OpenQC-VSCode
+- ORCA 6.1.1 Manual: https://orca-manual.mpi-muelheim.mpg.de/
+- ORCA 6.0 Tutorials: https://www.faccts.de/docs/orca/6.0/tutorials/
+- ORCA Input Library: https://sites.google.com/site/orcainputlibrary/home
+- CompoundScripts: https://github.com/ORCAQuantumChemistry/CompoundScripts
+- ORCA-LSP GitHub: https://github.com/newtontech/orca-lsp
+- OpenQC-VSCode: https://github.com/newtontech/OpenQC-VSCode
 
 ---
 

--- a/log.md
+++ b/log.md
@@ -80,4 +80,67 @@
 
 ---
 
+## 2026-06-12 - 文档扩展 / Documentation Expansion
+
+### 操作 / Operation
+通过网络搜索收集ORCA官方文档，扩展原始资料和wiki知识库。
+
+### 新增原始资料 / New Raw Assets
+
+1. `raw/assets/orca-input-format.md` -- ORCA输入文件格式官方文档（ORCA 6.1.1 Manual Section 2.1）
+2. `raw/assets/orca-keywords-reference.md` -- ORCA关键字完整参考（方法、基组、作业类型、SCF控制、色散、RI等）
+3. `raw/assets/orca-examples.md` -- 18个ORCA输入文件示例（涵盖DFT、TD-DFT、MP2、DLPNO-CCSD(T)、CPCM、TS等）
+4. `raw/assets/orca-output-format.md` -- ORCA输出文件格式参考（主输出、property.txt、解析模式）
+5. `raw/assets/orca-compound-jobs.md` -- 复合作业与多步工作流文档（$new_job、Compound模块、OPI）
+6. `raw/assets/orca-basis-sets-reference.md` -- ORCA基组完整参考（def2、cc-pVXZ、SARC、ANO、ECP等）
+7. `raw/assets/orca-github-tools.md` -- GitHub ORCA工具与解析器（orca_parser、cclib、ASE、OPI等）
+8. `raw/assets/orca-tutorials.md` -- ORCA教程与学习资源汇总
+
+### 新增Wiki页面 / New Wiki Pages
+
+#### 实体页面 / Entity Pages (wiki/entities/)
+1. `ORCA_Official_Documentation.md` - ORCA官方文档资源汇总（7个核心来源）
+2. `ORCA_GitHub_Tools.md` - ORCA相关工具与解析器
+
+#### 概念页面 / Concept Pages (wiki/concepts/)
+1. `Compound_Jobs.md` - 复合作业与工作流（4种实现方式、4种常见模式）
+
+#### 综合页面 / Synthesis Pages (wiki/synthesis/)
+1. `ORCA_Output_Guide.md` - ORCA输出文件解析指南（6个关键段、3种解析策略）
+
+### 更新的Wiki页面 / Updated Wiki Pages
+
+1. `ORCA_Quantum_Chemistry.md` - 添加新原始资料来源引用
+2. `Basis_Sets.md` - 添加基组参考文档来源
+3. `Input_File_Guide.md` - 添加5个新原始资料来源
+
+### 关键发现 / Key Findings
+
+1. **ORCA 6.1.1 Manual** 是最全面的文档来源，在线托管于 orca-manual.mpi-muelheim.mpg.de
+2. **ORCA 6.0 Tutorials** (FACCTs) 提供面向新用户的教程，覆盖安装到高级计算
+3. **ORCA Input Library** 是社区维护的输入示例库，但尚未更新至ORCA 6.0
+4. **CompoundScripts** 是ORCA官方GitHub组织的唯一公开仓库
+5. **RIJCOSX** 从ORCA 5.0起对杂化泛函默认启用
+6. **DefGrid1/2/3** 取代了ORCA 5.0前的GridX关键字
+7. **orca_parser** 和 **cclib** 是两个主要的ORCA输出解析Python库
+
+### 数据来源 / Data Sources
+
+- ORCA 6.1.1 Manual (MPI Mulheim): https://orca-manual.mpi-muelheim.mpg.de/
+- ORCA 6.0 Tutorials (FACCTs): https://www.faccts.de/docs/orca/6.0/tutorials/
+- ORCA Input Library: https://sites.google.com/site/orcainputlibrary/home
+- CompoundScripts GitHub: https://github.com/ORCAQuantumChemistry/CompoundScripts
+- GitHub Topics orca-quantum-chemistry: https://github.com/topics/orca-quantum-chemistry
+- Texas A&M HPRC Tutorial: https://hprc.tamu.edu/training/intro_orca.html
+
+### 统计 / Statistics
+
+- **总Wiki文件**：29（新增4个）
+- **实体页面**：14（新增2个）
+- **概念页面**：11（新增1个）
+- **综合页面**：4（新增1个）
+- **原始资料**：18+文件（新增8个）
+
+---
+
 *本文档由LLM自动维护，记录知识库的所有重要变更。*

--- a/raw/assets/orca-basis-sets-reference.md
+++ b/raw/assets/orca-basis-sets-reference.md
@@ -1,0 +1,207 @@
+# ORCA Basis Sets Reference
+
+> Sources:
+> - ORCA 6.1.1 Manual -- Basis Sets (Section 2.7): https://orca-manual.mpi-muelheim.mpg.de/contents/essentialelements/basisset.html
+> - ORCA Input Library -- Basis Sets: https://sites.google.com/site/orcainputlibrary/basis-sets
+> - ORCA 6.0 Manual -- Choice of Basis Set: https://www.faccts.de/docs/orca/6.0/manual/contents/detailed/basisset.html
+> - Pantazis DFT-BasisSets Lecture: https://pc2.uni-paderborn.de/fileadmin/pc2/events/2020-02-10_Winterschool/Pantazis_DFT-BasisSets.pdf
+> Collected: 2026-06-12
+
+## Orbital Basis Sets
+
+### Karlsruhe def2 Series (Ahlrichs)
+Most commonly used in ORCA. Available for H-Rn (elements 1-86).
+
+| Keyword | Quality | Polarization | Typical Use |
+|---------|---------|-------------|-------------|
+| `def2-SV(P)` | Double-zeta | Reduced | Quick screening |
+| `def2-SVP` | Double-zeta | Single | Standard DFT |
+| `def2-TZVP` | Triple-zeta | Single | Production DFT |
+| `def2-TZVPP` | Triple-zeta | Double | High-quality DFT |
+| `def2-QZVP` | Quadruple-zeta | Single | Benchmark |
+| `def2-QZVPP` | Quadruple-zeta | Double | Near-CBS |
+
+### Pople Basis Sets
+Classic basis sets, well-tested for organic molecules.
+
+| Keyword | Quality | Notes |
+|---------|---------|-------|
+| `STO-3G` | Minimal | Educational only |
+| `3-21G` | Small split-valence | Quick estimates |
+| `6-31G` | Split-valence | Basic |
+| `6-31G*` | Split-valence + d | Standard |
+| `6-31G**` | Split-valence + d,p | With H polarization |
+| `6-311G*` | Triple-zeta + d | Better quality |
+| `6-311G**` | Triple-zeta + d,p | With H polarization |
+| `6-311+G**` | Triple-zeta + diffuse + d,p | Anions, Rydberg |
+
+### Dunning Correlation-Consistent Basis Sets
+Designed for correlated methods (MP2, CCSD, etc.).
+
+| Keyword | Quality | Notes |
+|---------|---------|-------|
+| `cc-pVDZ` | Double-zeta | Standard correlated |
+| `cc-pVTZ` | Triple-zeta | Production correlated |
+| `cc-pVQZ` | Quadruple-zeta | Benchmark |
+| `cc-pV5Z` | Quintuple-zeta | Near-CBS |
+| `aug-cc-pVDZ` | + diffuse | Anions, TD-DFT |
+| `aug-cc-pVTZ` | + diffuse | Production TD-DFT |
+| `aug-cc-pVQZ` | + diffuse | High-accuracy TD-DFT |
+| `cc-pCVXZ` | Core-valence | Core correlation |
+| `cc-pwCVXZ` | Weighted core-valence | Core correlation |
+
+### Jensen Polarization-Consistent (pcs/pcseg)
+Efficient for DFT, systematic convergence.
+
+| Keyword | Quality |
+|---------|---------|
+| `pc-1` / `pcseg-1` | Double-zeta |
+| `pc-2` / `pcseg-2` | Triple-zeta |
+| `pc-3` / `pcseg-3` | Quadruple-zeta |
+| `pc-4` / `pcseg-4` | Quintuple-zeta |
+| `aug-pcseg-1` through `aug-pcseg-4` | With diffuse |
+
+### Sapporo Basis Sets
+For heavier elements.
+
+| Keyword | Notes |
+|---------|-------|
+| `Sapporo-DKH3-DZP` | DKH double-zeta |
+| `Sapporo-DKH3-TZP` | DKH triple-zeta |
+| `Sapporo-DKH3-QZP` | DKH quadruple-zeta |
+
+### ANO (Atomic Natural Orbital) Basis Sets
+Compact and systematic.
+
+| Keyword | Notes |
+|---------|-------|
+| `ANO-RCC-MB` | Minimal contraction |
+| `ANO-RCC-VDZP` | Double-zeta + polarization |
+| `ANO-RCC-VTZP` | Triple-zeta + polarization |
+| `ANO-RCC-VQZP` | Quadruple-zeta + polarization |
+
+## Relativistic Basis Sets
+
+For calculations with ZORA, DKH, or X2C Hamiltonians.
+
+| Keyword | Method | Quality |
+|---------|--------|---------|
+| `SARC-ZORA-SVP` | ZORA | Double-zeta |
+| `SARC-ZORA-TZVP` | ZORA | Triple-zeta |
+| `SARC-ZORA-QZVP` | ZORA | Quadruple-zeta |
+| `SARC-DKH-SVP` | DKH | Double-zeta |
+| `SARC-DKH-TZVP` | DKH | Triple-zeta |
+| `SARC-DKH-QZVP` | DKH | Quadruple-zeta |
+| `SARC2-ZORA-TZVP` | ZORA | Updated SARC (lanthanides) |
+| `x2c-TZVPall` | X2C | All-electron triple-zeta |
+| `x2c-TZVPPall` | X2C | All-electron triple-zeta double-pol |
+
+## Auxiliary Basis Sets
+
+### Coulomb-Fitting (AuxJ)
+
+| Keyword | For Orbital | Notes |
+|---------|------------|-------|
+| `def2/J` | All def2 orbital | Universal Coulomb fitting |
+| `SARC/J` | All SARC orbital | Relativistic Coulomb fitting |
+| `x2c/J` | All x2c orbital | X2C Coulomb fitting |
+
+### Coulomb+Exchange-Fitting (AuxJK)
+
+| Keyword | For Orbital | Notes |
+|---------|------------|-------|
+| `def2/JK` | def2 orbital | Coulomb + exchange fitting |
+
+### Correlation-Fitting (AuxC)
+
+| Keyword | For Orbital | Notes |
+|---------|------------|-------|
+| `def2-SVP/C` | def2-SVP | MP2/CC correlation |
+| `def2-TZVP/C` | def2-TZVP | MP2/CC correlation |
+| `def2-TZVPP/C` | def2-TZVPP | MP2/CC correlation |
+| `def2-QZVPP/C` | def2-QZVPP | MP2/CC correlation |
+
+### F12 Complementary Auxiliary (CABS)
+
+| Keyword | For Orbital | Notes |
+|---------|------------|-------|
+| `cc-pVXZ-F12-CABS` | cc-pVXZ-F12 | F12 explicitly correlated |
+
+### AutoAux
+
+The `AutoAux` keyword generates auxiliary basis sets automatically for any orbital basis set that doesn't have a predefined auxiliary.
+
+## Effective Core Potentials (ECPs)
+
+For heavy elements (transition metals, lanthanides, actinides).
+
+| Keyword | Element Range | Notes |
+|---------|--------------|-------|
+| `def2-ECP` | Rb-Rn | Standard for def2 series |
+| `SDS(60,MDF)` | Lanthanides | Stuttgart-Dresden small-core |
+| `SDS(28,MWB)` | 3d transition metals | Small-core ECP |
+| `SDS(46,MWB)` | 4d transition metals | Small-core ECP |
+
+## Basis Set Assignment Methods
+
+### Global (Simple Input)
+
+```
+! B3LYP def2-TZVP
+```
+
+### Per-Element (via %basis block)
+
+```
+%basis
+  NewGTO H "def2-SVP" end
+  NewGTO C "def2-TZVP" end
+end
+```
+
+### Per-Atom
+
+```
+%basis
+  NewGTO 1 "def2-TZVP" end
+  NewGTO 2 "def2-SVP" end
+end
+```
+
+### From File
+
+```
+%basis
+  GTOName "mybasis.bas"
+end
+```
+
+## Recommended Basis Set Choices
+
+| Calculation Type | Basis Set | Reason |
+|-----------------|-----------|--------|
+| Quick screening | def2-SVP | Fast, reasonable |
+| Standard DFT | def2-TZVP | Good balance of cost/accuracy |
+| Production DFT | def2-TZVP + D3BJ | With dispersion |
+| High-quality DFT | def2-TZVPP or def2-QZVP | Larger basis |
+| MP2 | def2-TZVP/C | With correlation auxiliary |
+| DLPNO-CCSD(T) | def2-TZVPP/C | With correlation auxiliary |
+| Benchmark | def2-QZVPP/C | Near CBS |
+| TD-DFT | def2-TZVP or aug-cc-pVTZ | Diffuse functions important |
+| Anions | aug-cc-pVTZ or def2-TZVPPD | Diffuse functions required |
+| Heavy elements (relativistic) | SARC-ZORA-TZVP or x2c-TZVPall | With ZORA/DKH/X2C |
+| Composite methods | Built-in (B97-3c, PBEh-3c) | Pre-optimized basis |
+
+## Basis Set and Method Requirements
+
+Not all methods need all basis set types:
+
+| Method | Orbital | AuxJ | AuxJK | AuxC |
+|--------|---------|------|-------|------|
+| HF | Yes | Optional (RI-J) | Optional (RI-JK) | No |
+| DFT (pure) | Yes | Recommended (RI-J) | No | No |
+| DFT (hybrid) | Yes | Yes (RIJCOSX) | Optional | No |
+| MP2 | Yes | Yes | No | Recommended |
+| CCSD(T) | Yes | Yes | No | Recommended |
+| DLPNO-CCSD(T) | Yes | Yes | No | Required |
+| CASSCF | Yes | Optional | Optional | No |

--- a/raw/assets/orca-compound-jobs.md
+++ b/raw/assets/orca-compound-jobs.md
@@ -1,0 +1,183 @@
+# ORCA Compound Jobs and Multi-Step Workflows
+
+> Sources:
+> - ORCA 6.1.1 Manual -- Compound: https://orca-manual.mpi-muelheim.mpg.de/contents/workflowsautomatization/compound.html
+> - ORCA 6.0 Tutorials -- Compound Jobs: https://www.faccts.de/docs/orca/6.0/tutorials/workflows/compound_jobs.html
+> - CompoundScripts GitHub: https://github.com/ORCAQuantumChemistry/CompoundScripts
+> - ORCA 6.1 Manual -- Compound Examples: https://www.faccts.de/docs/orca/6.1/manual/contents/workflowsautomatization/compound_examples.html
+> Collected: 2026-06-12
+
+## Overview
+
+ORCA's **Compound** feature is the recommended way to combine multiple calculation steps into a single input file. It replaces the deprecated `$new_job` syntax.
+
+### Deprecated: $new_job
+
+```
+# WARNING: $new_job is deprecated
+! B3LYP def2-SVP SP
+* xyz 0 1
+  O 0 0 0
+  H 0 0 1
+  H 0 1 0
+*
+$new_job
+! B3LYP def2-TZVP SP
+* xyz 0 1
+  O 0 0 0
+  H 0 0 1
+  H 0 1 0
+*
+```
+
+### Recommended: Compound Module
+
+The Compound module allows:
+- Chaining calculations with different methods/basis sets
+- Passing results between steps (geometries, orbitals, energies)
+- Python-style scripting within ORCA
+- Automated plotting and analysis
+
+## Compound Use Cases
+
+1. **Optimization + Frequency**: Optimize geometry, then compute frequencies
+2. **Multi-Level Single Points**: Cheap optimization, expensive single point
+3. **Extrapolation**: Multiple basis sets for CBS extrapolation
+4. **Spectroscopy Pipeline**: Optimize -> frequency -> excited states
+5. **Conformer Search**: GOAT + refinement
+
+## Common Workflow Patterns
+
+### Pattern 1: Opt + Freq (Combined Keywords)
+
+The simplest approach -- just combine `OPT` and `FREQ` keywords:
+
+```
+! B3LYP def2-TZVP OPT FREQ D3BJ TightSCF
+%maxcore 4000
+%pal nprocs 4 end
+
+* xyz 0 1
+  O   0.000000   0.000000   0.000000
+  H   0.757160   0.586260   0.000000
+  H  -0.757160   0.586260   0.000000
+*
+```
+
+### Pattern 2: Cheap Opt + Expensive SP (Using $new_job -- deprecated but still used)
+
+```
+# Step 1: Cheap optimization
+! B3LYP def2-SVP OPT TightSCF
+%maxcore 4000
+* xyz 0 1
+  O   0.0  0.0  0.0
+  H   0.0  0.0  1.0
+  H   0.0  1.0  0.0
+*
+
+$new_job
+
+# Step 2: High-accuracy single point on optimized geometry
+! DLPNO-CCSD(T) def2-TZVPP def2-TZVPP/C TightSCF
+%maxcore 8000
+* xyzfile 0 1
+```
+
+### Pattern 3: Multi-Method Property Calculation
+
+```
+# Step 1: DFT optimization
+! B3LYP def2-TZVP OPT TightSCF KeepInts
+%maxcore 4000
+* xyz 0 1
+  B  0 0 0  0      0 0
+  O  1 0 0  1.2049 0 0
+*
+
+$new_job
+
+# Step 2: Property calculation with different functional
+! BP86 def2-TZVP SmallPrint ReadInts
+%eprnmr gtensor 1 end
+* xyz 0 1
+  B  0 0 0  0      0 0
+  O  1 0 0  1.2049 0 0
+*
+```
+
+## CompoundScripts Library
+
+The official `CompoundScripts` repository (https://github.com/ORCAQuantumChemistry/CompoundScripts) provides ready-made scripts for common workflows.
+
+### Available Scripts Include:
+- Basis set extrapolation
+- BSSE-corrected interaction energies
+- Multi-step optimization protocols
+- Automated spectral simulations
+- Conformer search pipelines
+
+## ORCA Python Interface (OPI)
+
+For more complex automation, ORCA 6.1+ provides the Python Interface:
+
+```python
+# Pseudocode for OPI workflow
+from orca import OPI
+
+# Create input
+inp = OPI.Input()
+inp.method = "B3LYP"
+inp.basis = "def2-TZVP"
+inp.job_type = "OPT"
+
+# Run calculation
+result = OPI.run(inp)
+
+# Extract optimized geometry
+geometry = result.get_geometry()
+
+# Create single-point job with optimized geometry
+sp_inp = OPI.Input()
+sp_inp.method = "DLPNO-CCSD(T)"
+sp_inp.basis = "def2-TZVPP"
+sp_inp.geometry = geometry
+
+sp_result = OPI.run(sp_inp)
+energy = sp_result.get_energy()
+```
+
+## Extrapolation Techniques
+
+### Two-Point Basis Set Extrapolation
+
+For CBS (complete basis set) extrapolation:
+
+```
+# Step 1: Triple-zeta calculation
+! CCSD(T) def2-TZVPP def2-TZVPP/C TightSCF
+%maxcore 8000
+* xyz 0 1
+  ...
+*
+
+$new_job
+
+# Step 2: Quadruple-zeta calculation
+! CCSD(T) def2-QZVPP def2-QZVPP/C TightSCF
+%maxcore 16000
+* xyz 0 1
+  ...
+*
+```
+
+Then extrapolate: E(CBS) = E(QZ) + (E(QZ) - E(TZ)) / ( (4/3)^3 - 1 )
+
+## Input Priority in Multi-Step Jobs
+
+When using `$new_job`:
+- All calculation flags are transferred from the previous job
+- Only changes need to be specified
+- The new job takes orbitals from the old job by default
+- To override, specify your own guess explicitly
+- If you enabled RI for one job, it carries over (turn off manually if not wanted)

--- a/raw/assets/orca-examples.md
+++ b/raw/assets/orca-examples.md
@@ -1,0 +1,306 @@
+# ORCA Example Input Files Collection
+
+> Sources:
+> - ORCA Input Library: https://sites.google.com/site/orcainputlibrary/home
+> - ORCA 6.0 Tutorials (FACCTs): https://www.faccts.de/docs/orca/6.0/tutorials/
+> - ORCA Manual Examples: https://orca-manual.mpi-muelheim.mpg.de/
+> - Project examples: /Users/yhm/Desktop/code/orca-lsp/examples/
+> Collected: 2026-06-12
+
+## 1. Basic Single Point Energy (HF/def2-SVP)
+
+```
+! HF def2-SVP
+
+* xyz 0 1
+O   0.0000   0.0000   0.0626
+H  -0.7920   0.0000  -0.4973
+H   0.7920   0.0000  -0.4973
+*
+```
+
+## 2. DFT Geometry Optimization + Frequency (B3LYP/def2-TZVP)
+
+```
+! B3LYP def2-TZVP OPT FREQ D3BJ
+%maxcore 4000
+%pal nprocs 4 end
+
+* xyz 0 1
+  O   0.000000   0.000000   0.000000
+  H   0.757160   0.586260   0.000000
+  H  -0.757160   0.586260   0.000000
+*
+```
+
+## 3. High-Accuracy Single Point (DLPNO-CCSD(T)/def2-TZVPP)
+
+```
+! DLPNO-CCSD(T) def2-TZVPP def2-TZVPP/C SP TightSCF
+%maxcore 8000
+%pal nprocs 8 end
+
+* xyz 0 1
+  C   1.390000   0.000000   0.000000
+  C   0.695000   1.203781   0.000000
+  C  -0.695000   1.203781   0.000000
+  C  -1.390000   0.000000   0.000000
+  C  -0.695000  -1.203781   0.000000
+  C   0.695000  -1.203781   0.000000
+  H   2.470000   0.000000   0.000000
+  H   1.235000   2.139088   0.000000
+  H  -1.235000   2.139088   0.000000
+  H  -2.470000   0.000000   0.000000
+  H  -1.235000  -2.139088   0.000000
+  H   1.235000  -2.139088   0.000000
+*
+```
+
+## 4. TD-DFT Excited States
+
+```
+! B3LYP def2-TZVP SP TightSCF
+%maxcore 4000
+%pal nprocs 4 end
+%tddft
+  nroots 10
+  maxdim 100
+end
+
+* xyz 0 1
+  C   0.000000   0.000000   0.000000
+  O   1.200000   0.000000   0.000000
+  H  -0.500000   0.900000   0.000000
+  H  -0.500000  -0.900000   0.000000
+*
+```
+
+## 5. TD-DFT with Range-Separated Functional
+
+```
+! CAM-B3LYP def2-TZVP TightSCF DefGrid3 SP
+%maxcore 6000
+%pal nprocs 8 end
+%tddft
+  nroots 20
+  maxdim 200
+end
+
+* xyz 0 1
+  C   0.000000   0.000000   0.000000
+  N   1.200000   0.000000   0.000000
+  H  -0.500000   0.900000   0.000000
+  H  -0.500000  -0.900000   0.000000
+*
+```
+
+## 6. Solvation (CPCM)
+
+```
+! B3LYP def2-SVP OPT CPCM(Water) D3BJ
+%maxcore 4000
+%pal nprocs 4 end
+%cpcm
+  epsilon 80.4
+  refrac 1.33
+end
+
+* xyz 0 1
+  C   0.000000   0.000000   0.000000
+  O   1.200000   0.000000   0.000000
+  H  -0.500000   0.900000   0.000000
+  H  -0.500000  -0.900000   0.000000
+*
+```
+
+## 7. Transition State Search
+
+```
+! B3LYP def2-TZVP TS TightSCF
+%maxcore 4000
+%pal nprocs 8 end
+%geom
+  Calc_Hess true
+  Recalc_Hess 5
+end
+
+* xyz 0 1
+  C   0.000000   0.000000   0.000000
+  O   1.200000   0.000000   0.000000
+  H  -0.500000   0.900000   0.000000
+  H  -0.500000  -0.900000   0.000000
+*
+```
+
+## 8. MP2 Frequency Calculation
+
+```
+! MP2 def2-TZVP FREQ TightSCF
+%maxcore 4000
+%pal nprocs 4 end
+%freq temp 298.15 end
+
+* xyz 0 1
+  C   0.000000   0.000000   0.667000
+  C   0.000000   0.000000  -0.667000
+  H   0.000000   0.920000   1.230000
+  H   0.000000  -0.920000   1.230000
+  H   0.000000   0.920000  -1.230000
+  H   0.000000  -0.920000  -1.230000
+*
+```
+
+## 9. Counterpoise Correction (BSSE)
+
+```
+! MP2 def2-TZVP SP TightSCF
+%maxcore 4000
+%pal nprocs 4 end
+%cp
+  fragments 2
+  charge(1) 0 1
+  charge(2) 0 1
+end
+
+* xyz 0 1
+  O   0.000000   0.000000   0.000000
+  H   0.757160   0.586260   0.000000
+  H  -0.757160   0.586260   0.000000
+  O   0.000000   0.000000   3.000000
+  H   0.757160   0.586260   3.000000
+  H  -0.757160   0.586260   3.000000
+*
+```
+
+## 10. Open-Shell Radical (OH Radical)
+
+```
+! UHF def2-SVP
+* int 0 2
+O  0 0 0 0.0    0.0 0.0
+H  1 0 0 0.9903 0.0 0.0
+*
+```
+
+## 11. Reading Coordinates from External File
+
+```
+! B3LYP def2-TZVP OPT TightSCF
+%maxcore 4000
+* xyzfile 0 1 molecule.xyz
+```
+
+## 12. SCF Convergence Control
+
+```
+! B3LYP def2-TZVP SP
+%scf
+  MaxIter 500
+  Convergence Tight
+  Guess PModel
+  Damping 0.2
+end
+%maxcore 4000
+
+* xyz 0 1
+  Fe  0.0  0.0  0.0
+  C   0.0  0.0  1.8
+  O   0.0  0.0  3.0
+*
+```
+
+## 13. Relativistic Calculation (ZORA)
+
+```
+! ZORA B3LYP SARC-ZORA-TZVP def2/J TightSCF SP
+%rel
+  method ZORA
+  picturechange true
+end
+
+* xyz 0 1
+  Pt  0.0  0.0  0.0
+  Cl  2.3  0.0  0.0
+  Cl -2.3  0.0  0.0
+*
+```
+
+## 14. Custom Basis Set Assignment
+
+```
+! B3LYP TightSCF SP
+%basis
+  NewGTO H "def2-SVP" end
+  NewGTO C "def2-TZVP" end
+  NewAuxGTO H "def2/J" end
+  NewAuxGTO C "def2/J" end
+end
+
+* xyz 0 1
+  C   0.0  0.0  0.0
+  H   0.0  0.0  1.09
+  H   1.03 0.0  -0.36
+  H  -0.51 0.89  -0.36
+  H  -0.51 -0.89  -0.36
+*
+```
+
+## 15. PES Scan
+
+```
+! B3LYP def2-TZVP SP
+%geom
+  Scan
+    B 0 1 = 0.9, 1.2, 16
+  end
+end
+
+* xyz 0 1
+  O  0.0  0.0  0.0
+  H  0.9  0.0  0.0
+  H -0.5  0.8  0.0
+*
+```
+
+## 16. Frozen Core Calculation
+
+```
+! DLPNO-CCSD(T) def2-TZVPP def2-TZVPP/C TightSCF FrozenCore SP
+%maxcore 8000
+%pal nprocs 8 end
+
+* xyz 0 1
+  Cu  0.0  0.0  0.0
+  Cl  2.3  0.0  0.0
+  Cl -2.3  0.0  0.0
+  Cl  0.0  2.3  0.0
+  Cl  0.0 -2.3  0.0
+*
+```
+
+## 17. Implicit Solvation with SMD
+
+```
+! B3LYP def2-TZVP OPT SMD(Water) D3BJ TightSCF
+%maxcore 4000
+
+* xyz 0 1
+  O   0.000000   0.000000   0.000000
+  H   0.757160   0.586260   0.000000
+  H  -0.757160   0.586260   0.000000
+*
+```
+
+## 18. Unrestricted Calculation (Triplet O2)
+
+```
+! UKS B3LYP def2-TZVP TightSCF SP
+%scf
+  Guess PModel
+end
+
+* xyz 0 3
+  O  0.0  0.0  0.0
+  O  1.2  0.0  0.0
+*
+```

--- a/raw/assets/orca-github-tools.md
+++ b/raw/assets/orca-github-tools.md
@@ -1,0 +1,114 @@
+# ORCA-Related Tools, Parsers, and Converters (GitHub)
+
+> Sources:
+> - GitHub Topics: https://github.com/topics/orca-quantum-chemistry
+> - GitHub search results for ORCA parser/converter tools
+> Collected: 2026-06-12
+
+## Official ORCA Repositories
+
+### ORCAQuantumChemistry Organization
+- URL: https://github.com/ORCAQuantumChemistry
+- The official GitHub organization for ORCA Quantum Chemistry.
+
+### CompoundScripts
+- URL: https://github.com/ORCAQuantumChemistry/CompoundScripts
+- Official repository containing compound scripts for automating workflows within ORCA.
+- Allows users to automate complicated calculations directly within ORCA.
+- 113+ stars, 25+ forks.
+
+## ORCA Output Parsers
+
+### orca_parser
+- URL: https://github.com/avanteijlingen/orca_parser
+- PyPI: https://pypi.org/project/orca-parser/
+- Install: `pip install orca-parser`
+- Python module for parsing data from ORCA output files.
+- Extracts energies, geometries, frequencies, and other computed properties.
+
+### cclib (via parse-patrol)
+- URL: https://github.com/ndaelman-hu/parse-patrol
+- MCP servers for agentic parser tools for quantum chemistry output files.
+- Wraps cclib: multi-format parser supporting Gaussian, ORCA, and many other QC programs.
+- Also wraps iodata for various chemistry format parsing.
+
+### qccodec
+- URL: https://github.com/coltonbh/qccodec
+- A library for parsing quantum chemistry I/O.
+- Encodes inputs into native QC files, decodes (parses) program outputs into structured `qcdata` objects.
+- Supports ORCA among multiple formats.
+
+### qccop (qccompute)
+- URL: https://github.com/coltonbh/qcop
+- A package for operating Quantum Chemistry programs using `qcio` standardized data structures.
+- Compatible with TeraChem, psi4, QChem, NWChem, ORCA, Molpro, and more.
+
+## ORCA Automation Tools
+
+### Parallelized-DFT-ORCA
+- URL: https://github.com/aspuru-guzik-group/Parallelized-DFT-ORCA
+- Automates the full workflow: geometry optimization -> frequency checks -> vertical excitation energy calculations -> NTO analysis.
+- From the Aspuru-Guzik group.
+
+### ORCA_run
+- URL: https://github.com/glibaniosr/ORCA_run
+- Shell/bash script to help start and run electronic structure calculations with ORCA.
+
+### qtaim_generator
+- URL: https://github.com/santi921/qtaim_generator
+- High-throughput post-processing package wrapping Multiwfn and ORCA for QTAIM descriptors.
+
+## ORCA Interfaces
+
+### ASE (Atomic Simulation Environment) ORCA Calculator
+- Docs: https://ase-lib.org/ase/calculators/orca.html
+- Interface for running ORCA calculations from the ASE Python framework.
+- Supports SCF, (TD)DFT, semi-empirical, MP2, CASSCF, and coupled cluster.
+
+### ASH Framework ORCA Interface
+- Docs: https://ash.readthedocs.io/en/latest/ORCA-interface.html
+- Highly flexible interface to ORCA handling input generation, output parsing, and data extraction.
+
+### ORCA Python Interface (OPI)
+- Paper: https://pubs.acs.org/doi/10.1021/acs.jctc.5c02141
+- Open-source Python interface for ORCA input creation, job execution, and output parsing.
+- Released with ORCA 6.1.
+
+### Multiwfn + ORCA
+- URL: http://sobereva.com/multiwfn/
+- Multiwfn can generate ORCA input files and process ORCA output for wavefunction analysis.
+
+## AI/ML Tools for ORCA
+
+### DELFIN
+- URL: https://github.com/ComPlat/DELFIN
+- Open-source AI-orchestrated computational chemistry platform.
+- Automates first-principles molecular property prediction.
+
+### Q-stack
+- URL: https://github.com/lcmd-epfl/Q-stack
+- Stack of codes for pre- and post-processing tasks for Quantum Machine Learning.
+- Python-based library with broad QC support.
+
+### GUIDE
+- Paper: https://onlinelibrary.wiley.com/doi/full/10.1002/jcc.27177
+- GUI tool (YASARA plugin) for automated quantum chemistry calculations.
+- Supports ORCA and MOPAC simulation packages.
+
+## File Format Tools
+
+### orca_2json
+- Part of ORCA utilities (documented in ORCA manual section 9.3).
+- Converts ORCA output to JSON format for programmatic access.
+
+### OpenBabel
+- URL: https://github.com/openbabel/openbabel
+- Can convert between chemical file formats including XYZ (used by ORCA).
+
+## Key Takeaways for orca-lsp
+
+1. **Parsing patterns**: The `orca_parser` and `cclib` projects provide reference implementations for parsing ORCA output files.
+2. **Input validation**: The `ASE` and `ASH` interfaces show how to programmatically generate valid ORCA input.
+3. **Compound scripts**: The official `CompoundScripts` repository demonstrates multi-step workflow patterns.
+4. **Structured output**: The `orca_2JSON` utility and `property.txt` file format provide machine-readable output.
+5. **Keyword validation**: Tools like `Multiwfn` and `qccodec` maintain keyword lists that can inform LSP autocompletion.

--- a/raw/assets/orca-input-format.md
+++ b/raw/assets/orca-input-format.md
@@ -1,0 +1,245 @@
+# ORCA Input File Format Reference
+
+> Source: ORCA 6.1.1 Manual -- Section 2.1 General Structure of the Input File
+> URL: https://orca-manual.mpi-muelheim.mpg.de/contents/essentialelements/input.html
+> Collected: 2026-06-12
+
+## General Structure
+
+The ORCA input file is a **free-format ASCII file** that can contain:
+
+1. **Simple keyword lines** starting with `!`
+2. **Input blocks** enclosed between `%` and `end`
+3. **Coordinate specification** with total charge and spin multiplicity, either via `%coords` block or enclosed between two `*` symbols
+
+### Minimal Example
+
+```
+! HF def2-TZVP
+
+%scf
+   convergence tight
+end
+
+* xyz 0 1
+C  0.0  0.0  0.0
+O  0.0  0.0  1.13
+*
+```
+
+### Comments
+
+Comments start with `#` and continue to end of line:
+
+```
+# This is a comment. Continues until the end of the line
+```
+
+Comments can also be closed by a second `#`:
+
+```
+TolE=1e-5;    #Energy conv.#  TolMaxP=1e-6; #Density conv.#
+```
+
+### Case Sensitivity
+
+- The ORCA input is **NOT case sensitive**. UPPER CASE, lower case, or aNy cOMmBINAtiON are allowed.
+- Exception: file names (e.g., for `%MOInp` or `*XYZName`) are case-sensitive on Unix-like OSs.
+- The order of simple keywords and input blocks is generally not important.
+
+## Input Blocks
+
+Input blocks start with `%`, followed by the block name, and end with `end`:
+
+```
+%scf
+   MaxIter 500
+   Convergence tight
+end
+```
+
+### Variable Assignment Syntax
+
+```
+VariableName Value
+# or with optional "="
+OtherVariableName = OtherValue
+```
+
+Values can be numeric, quote-delimited strings, or predefined aliases.
+
+### Array Syntax
+
+```
+Array[1]  Value1
+Array[1]  Value1,Value2,Value3
+Array  Value1,Value2
+```
+
+Note: Arrays always start with index 0 (ORCA is C++). `Array[1]` is the *second* element.
+
+### String Values
+
+Strings (filenames) must be enclosed in quotes:
+
+```
+%scf
+  MOInp "Myfile.gbw"
+end
+```
+
+### Nested Sub-Blocks
+
+Some keywords open nested sub-blocks closed with additional `end`:
+
+```
+%scf
+  Guess PModel        # variable assignment
+  SOSCF               # nested sub-block
+    start 0.002       # variable assignment
+  end                 # closes SOSCF sub-block
+end
+%basis
+  NewGTO              # nested sub-block
+    H "def2-SVP"
+    S 1
+    1 0.05 1.0
+  end                 # closes NewGTO
+end
+```
+
+### Single-Variable Blocks (No `end`)
+
+```
+%MOInp "MyFile.gbw"
+%maxcore 3000
+```
+
+## Input Priority and Processing Order
+
+1. All simple input lines (`!`) are collected into a single string.
+2. Known keywords are processed in a predefined order, regardless of input file order.
+3. For basis sets: if two different orbital basis sets are given (e.g., `! def2-SVP def2-TZVP`), the latter takes priority. Same for auxiliary basis sets of the same type.
+4. Some simple keywords set multiple internal variables -- more specific keywords take precedence.
+5. Block input is parsed in order. If a keyword is duplicated, the latter value is used.
+6. Multiple instances of the same block are not recommended.
+
+## Global Memory
+
+```
+%maxcore 2000   # 2000 MB per processing core
+```
+
+- Applies per processing core, not total.
+- Do not exceed 75-80% of physical memory.
+- Default: 4GB (plenty for standard DFT).
+- For coupled clusters: at least 8GB recommended.
+
+## BaseName
+
+ORCA generates output files starting with the same prefix (BaseName). Usually inferred from input filename.
+
+```
+%base "job1"   # all generated files start with "job1"
+```
+
+## Multi-Step Jobs ($new_job -- Deprecated)
+
+The `$new_job` feature is deprecated. Use the **Compound** feature instead.
+
+Example of deprecated syntax:
+
+```
+! LSD DEF2-SVP TightSCF KeepInts
+%eprnmr gtensor 1 end
+* int 0 2
+   B  0  0  0   0      0  0
+   O  1  0  0   1.2049 0  0
+*
+$new_job
+! BP86 DEF2-SVP SmallPrint ReadInts NoKeepInts
+%eprnmr gtensor 1 end
+* int 0 2
+   B  0  0  0   0      0  0
+   O  1  0  0   1.2049 0  0
+*
+```
+
+## Coordinate Input
+
+### Cartesian (xyz)
+
+```
+* xyz 0 1
+O   0.0000   0.0000   0.0626
+H  -0.7920   0.0000  -0.4973
+H   0.7920   0.0000  -0.4973
+*
+```
+
+### Internal Coordinates (int)
+
+```
+* int 0 2
+O  0 0 0 0.0    0.0 0.0
+H  1 0 0 0.9903 0.0 0.0
+*
+```
+
+### From External File
+
+```
+* xyzfile 0 2 hydroxide.xyz
+```
+
+### Atom Specification
+
+Atoms can be specified by symbol (H, C, Cu, Te) or atomic number (1, 6, 29, 52). Coordinates are in Angstroms.
+
+## List of Input Blocks (Table 2.1 from Manual)
+
+Major input blocks include:
+- `%scf` -- SCF convergence and method settings
+- `%method` -- Method/functional specification
+- `%basis` -- Basis set customization
+- `%geom` -- Geometry optimization controls
+- `%freq` -- Frequency calculation settings
+- `%tddft` / `%cis` -- Excited state calculations
+- `%mp2` -- MP2 correlation settings
+- `%mdci` -- Coupled cluster / CI settings
+- `%cpcm` -- Conductor-like PCM solvation
+- `%cosmo` -- COSMO solvation
+- `%eprnmr` -- EPR/NMR property settings
+- `%casscf` -- CASSCF multireference
+- `%pal` -- Parallel execution
+- `%output` -- Output format control
+- `%plots` -- Orbital/density plotting
+- `%moinp` -- MO input specification
+- `%rel` -- Relativistic settings
+- `%chkcoords` -- Coordinate checking
+- `%maxcore` -- Memory per core (no `end`)
+- `%base` -- BaseName (no `end`)
+
+## Simple Keyword Lines
+
+Simple input lines start with `!` and can contain any number of space-separated keywords:
+
+```
+! Keyword1 Keyword2
+! Keyword3
+```
+
+Multiple `!` lines are allowed. Common keyword categories:
+
+| Category | Examples |
+|----------|----------|
+| Methods | HF, B3LYP, PBE0, MP2, CCSD(T), DLPNO-CCSD(T) |
+| Basis Sets | def2-SVP, def2-TZVP, cc-pVTZ, 6-31G* |
+| Job Types | SP, OPT, FREQ, TS, IRC, SCAN |
+| SCF Control | TightSCF, VeryTightSCF, LooseSCF |
+| Dispersion | D3, D3BJ, D4 |
+| RI/DF | RIJCOSX, RI-JK, RI-J |
+| Grid | DefGrid1, DefGrid2, DefGrid3 |
+| Solvation | CPCM(Water), SMD(Water) |
+| Output | PrintLevel Mini, SmallPrint, LargePrint |
+| Spin | UKS, RKS, ROKS |

--- a/raw/assets/orca-keywords-reference.md
+++ b/raw/assets/orca-keywords-reference.md
@@ -1,0 +1,342 @@
+# ORCA Keywords Reference
+
+> Sources:
+> - ORCA 6.1.1 Manual: https://orca-manual.mpi-muelheim.mpg.de/contents/essentialelements/index_essentialelements.html
+> - ORCA Input Library: https://sites.google.com/site/orcainputlibrary/home
+> - ORCA 6.0 Tutorials (FACCTs): https://www.faccts.de/docs/orca/6.0/tutorials/
+> - ORCA 5.0.4 Manual PDF: https://www.kofo.mpg.de/970316/orca_manual_5_0_4.pdf
+> Collected: 2026-06-12
+
+## Method Keywords
+
+### Hartree-Fock Methods
+| Keyword | Description |
+|---------|-------------|
+| `HF` | Hartree-Fock |
+| `RHF` | Restricted Hartree-Fock |
+| `UHF` | Unrestricted Hartree-Fock |
+| `ROHF` | Restricted Open-shell Hartree-Fock |
+
+### DFT Functionals (Selected)
+| Keyword | Type | Description |
+|---------|------|-------------|
+| `B3LYP` | Hybrid GGA | Most popular hybrid functional |
+| `PBE0` | Hybrid GGA | Perdew-Burke-Ernzerhof hybrid |
+| `BP86` | GGA | Becke exchange + Perdew correlation |
+| `BLYP` | GGA | Becke exchange + LYP correlation |
+| `PBE` | GGA | Perdew-Burke-Ernzerhof |
+| `TPSS` | meta-GGA | Tao-Perdew-Staroverov-Scuseria |
+| `M06` | meta-GGA | Minnesota 2006 |
+| `M06-2X` | meta-GGA | Minnesota high-nonlocality |
+| `M06-L` | meta-GGA | Minnesota local |
+| `CAM-B3LYP` | Range-separated | Long-range corrected B3LYP |
+| `wB97X-D` | Range-separated | Range-separated with dispersion |
+| `wB97X-D3` | Range-separated | Updated wB97X-D |
+| `B2PLYP` | Double hybrid | Grimme's double hybrid |
+| `DSD-PBEP86` | Double hybrid | Sanzhirov double hybrid |
+| `revDSD-PBEP86` | Double hybrid | Revised DSD-PBEP86 |
+| `LDA` / `SVWN` | LSDA | Local density approximation |
+
+### Semiempirical Methods
+| Keyword | Description |
+|---------|-------------|
+| `PM3` | Parameterized Model 3 |
+| `AM1` | Austin Model 1 |
+| `MNDO` | Modified Neglect of Differential Overlap |
+| `ZINDO/1` | Zerner INDO variant 1 |
+| `ZINDO/S` | Zerner INDO for spectroscopy |
+| `GFN2-xTB` | Grimme's extended Tight-Binding |
+| `GFN-FF` | Grimme's force field |
+
+### Composite Methods (3c)
+| Keyword | Description |
+|---------|-------------|
+| `B97-3c` | B97 with 3-correction composite |
+| `PBEh-3c` | PBE hybrid 3-correction |
+| `r2SCAN-3c` | r2SCAN 3-correction |
+| `HF-3c` | Hartree-Fock 3-correction |
+
+### Wavefunction Methods
+| Keyword | Description |
+|---------|-------------|
+| `MP2` | Second-order Moller-Plesset |
+| `MP3` | Third-order Moller-Plesset |
+| `CCSD` | Coupled cluster singles doubles |
+| `CCSD(T)` | CCSD with perturbative triples |
+| `DLPNO-CCSD` | Domain-based local pair natural orbital CCSD |
+| `DLPNO-CCSD(T)` | DLPNO-CCSD with perturbative triples |
+| `QCISD` | Quadratic CISD |
+| `CASSCF` | Complete active space SCF |
+
+## Basis Set Keywords
+
+### Karlsruhe def2 Series
+| Keyword | Description |
+|---------|-------------|
+| `def2-SVP` | Split-valence polarization (double-zeta quality) |
+| `def2-SV(P)` | Split-valence (reduced polarization) |
+| `def2-TZVP` | Triple-zeta valence polarization |
+| `def2-TZVPP` | Triple-zeta valence double polarization |
+| `def2-QZVP` | Quadruple-zeta valence polarization |
+| `def2-QZVPP` | Quadruple-zeta valence double polarization |
+
+### Pople Basis Sets
+| Keyword | Description |
+|---------|-------------|
+| `STO-3G` | Minimal basis |
+| `3-21G` | Small split-valence |
+| `6-31G` | Split-valence |
+| `6-31G*` / `6-31G(d)` | With polarization on heavy atoms |
+| `6-31G**` / `6-31G(d,p)` | With polarization on all atoms |
+| `6-311G*` / `6-311G(d)` | Triple-zeta with polarization |
+| `6-311G**` / `6-311G(d,p)` | Triple-zeta with full polarization |
+| `6-311+G**` | With diffuse functions |
+
+### Dunning Correlation-Consistent
+| Keyword | Description |
+|---------|-------------|
+| `cc-pVDZ` | Double-zeta correlation-consistent |
+| `cc-pVTZ` | Triple-zeta correlation-consistent |
+| `cc-pVQZ` | Quadruple-zeta correlation-consistent |
+| `cc-pV5Z` | Quintuple-zeta correlation-consistent |
+| `aug-cc-pVDZ` | With diffuse functions |
+| `aug-cc-pVTZ` | With diffuse functions |
+| `aug-cc-pVQZ` | With diffuse functions |
+
+### Jensen pcs-n / pcseg-n
+| Keyword | Description |
+|---------|-------------|
+| `pc-1` / `pcseg-1` | Polarization-consistent double-zeta |
+| `pc-2` / `pcseg-2` | Polarization-consistent triple-zeta |
+| `pc-3` / `pcseg-3` | Polarization-consistent quadruple-zeta |
+| `pc-4` / `pcseg-4` | Polarization-consistent quintuple-zeta |
+| `aug-pc-1` through `aug-pc-4` | With diffuse functions |
+
+### Relativistic Basis Sets
+| Keyword | Description |
+|---------|-------------|
+| `SARC-ZORA-TZVP` | ZORA-optimized triple-zeta |
+| `SARC-ZORA-QZVP` | ZORA-optimized quadruple-zeta |
+| `SARC-DKH-QZVP` | DKH-optimized quadruple-zeta |
+| `def2-TZVP(-f)` | def2 without f-functions (for ECP) |
+| `x2c-TZVPall` | X2C-optimized all-electron |
+
+### Auxiliary Basis Sets
+| Keyword | Type | Description |
+|---------|------|-------------|
+| `def2/J` | AuxJ | Coulomb fitting for def2 series |
+| `def2/JK` | AuxJK | Coulomb+exchange fitting for def2 |
+| `def2-TZVP/C` | AuxC | Correlation fitting |
+| `def2-TZVPP/C` | AuxC | Correlation fitting |
+| `SARC/J` | AuxJ | Coulomb fitting for SARC series |
+| `AutoAux` | Auto | Automatic generation |
+
+## Job Type Keywords
+
+| Keyword | Description |
+|---------|-------------|
+| `SP` | Single point energy |
+| `OPT` | Geometry optimization |
+| `FREQ` | Frequency calculation |
+| `TS` | Transition state search |
+| `IRC` | Intrinsic reaction coordinate |
+| `SCAN` | Potential energy surface scan |
+| `NEB-TS` | Nudged elastic band transition state |
+| `GOAT` | Global optimization and conformer search |
+
+## SCF Control Keywords
+
+| Keyword | Description |
+|---------|-------------|
+| `TightSCF` | Tight SCF convergence (default: 10^-8 Eh) |
+| `VeryTightSCF` | Very tight SCF convergence |
+| `ExtremeSCF` | Extreme SCF convergence |
+| `LooseSCF` | Loose SCF convergence |
+| `NormalSCF` | Normal SCF convergence |
+| `UKS` | Unrestricted Kohn-Sham |
+| `RKS` | Restricted Kohn-Sham |
+| `ROKS` | Restricted open-shell KS |
+
+## Dispersion Correction Keywords
+
+| Keyword | Description |
+|---------|-------------|
+| `D3` | Grimme D3 with zero-damping |
+| `D3BJ` | Grimme D3 with Becke-Johnson damping |
+| `D4` | Grimme D4 (charge-dependent) |
+| `VV10` | Non-local correlation (for wB97X-D etc.) |
+
+## RI/DF Keywords
+
+| Keyword | Description |
+|---------|-------------|
+| `RIJCOSX` | RI-J + COS-X approximation (default for hybrid DFT in ORCA >= 5.0) |
+| `RI-JK` | RI for both Coulomb and exchange |
+| `RI-J` | RI for Coulomb only |
+| `SPLIT-RI-J` | Split RI-J algorithm |
+| `RI-MP2` | RI-accelerated MP2 |
+| `DLPNO` | Domain-based local pair natural orbital |
+
+## Numerical Grid Keywords
+
+| Keyword | Description |
+|---------|-------------|
+| `DefGrid1` | Coarse grid (fast, less accurate) |
+| `DefGrid2` | Medium grid (default) |
+| `DefGrid3` | Fine grid (more accurate, slower) |
+| `GridX1` / `GridX2` / `GridX3` | COSX grid sizes |
+| `Grid1` through `Grid7` | DFT integration grid sizes (deprecated in ORCA 5.0+) |
+
+## Solvation Keywords
+
+| Keyword | Description |
+|---------|-------------|
+| `CPCM(Water)` | CPCM with Water dielectric |
+| `CPCM(solvent)` | CPCM with named solvent |
+| `COSMO(Water)` | COSMO with Water |
+| `SMD(Water)` | SMD solvation model |
+| `DRACO` | Dynamic radii adjustment for CPCM |
+
+## Output Control Keywords
+
+| Keyword | Description |
+|---------|-------------|
+| `SmallPrint` | Reduced output |
+| `LargePrint` | Extended output |
+| `PrintLevel Mini` | Minimal print level |
+| `NoPOP` | Suppress population analysis |
+| `KeepInts` | Keep integrals for subsequent jobs |
+| `ReadInts` | Read integrals from previous job |
+
+## Common Keyword Combinations
+
+### Standard DFT Optimization
+```
+! B3LYP def2-TZVP OPT FREQ D3BJ TightSCF
+```
+
+### High-Accuracy Single Point
+```
+! DLPNO-CCSD(T) def2-TZVPP def2-TZVPP/C TightSCF SP
+```
+
+### TD-DFT Excited States
+```
+! B3LYP def2-TZVP TightSCF SP
+%tddft
+  nroots 10
+end
+```
+
+### Geometry Optimization with Solvent
+```
+! B3LYP def2-SVP OPT CPCM(Water) D3BJ TightSCF
+```
+
+### Range-Separated Functional
+```
+! CAM-B3LYP def2-TZVP TightSCF DefGrid3
+```
+
+### Post-HF MP2
+```
+! MP2 def2-TZVP TightSCF RIJCOSX
+```
+
+## Percent Block Quick Reference
+
+### %scf
+```
+%scf
+  MaxIter 500
+  Convergence Tight
+  Guess PModel
+  Damping 0.2
+  LevelShift 0.5
+  SOSCF
+    start 0.002
+  end
+end
+```
+
+### %geom
+```
+%geom
+  MaxIter 50
+  Calc_Hess true
+  Recalc_Hess 5
+  Constraints
+    { B 1 2 1.5 C }
+  end
+  Trust 0.2
+end
+```
+
+### %tddft
+```
+%tddft
+  NRoots 10
+  MaxDim 100
+  IRoot 1
+  TDA false
+  DoRaman true
+end
+```
+
+### %cpcm
+```
+%cpcm
+  epsilon 80.4
+  refrac 1.33
+end
+```
+
+### %mp2
+```
+%mp2
+  MaxCore 4000
+  RI true
+  FreezeCore true
+end
+```
+
+### %pal
+```
+%pal
+  nprocs 8
+end
+```
+
+### %basis
+```
+%basis
+  NewGTO H "def2-SVP" end
+  NewAuxGTO H "def2/J" end
+  ECP Pt "def2-ECP" end
+end
+```
+
+### %mdci (Coupled Cluster)
+```
+%mdci
+  MaxIter 50
+  TCutPNO 1e-8
+  DLPNO true
+end
+```
+
+### %freq
+```
+%freq
+  Temp 298.15
+  ScaleFactor 0.957
+end
+```
+
+### %rel (Relativistic)
+```
+%rel
+  method ZORA
+  picturechange true
+end
+```

--- a/raw/assets/orca-output-format.md
+++ b/raw/assets/orca-output-format.md
@@ -1,0 +1,351 @@
+# ORCA Output File Format Reference
+
+> Sources:
+> - ORCA 6.0 Tutorials (Input and Output): https://www.faccts.de/docs/orca/6.0/tutorials/first_steps/input_output.html
+> - ORCA 6.1.1 Manual -- Property File: https://orca-manual.mpi-muelheim.mpg.de/contents/utilitiesvisualization/property_file.html
+> - ORCA 6.0 Manual -- Property File: https://www.faccts.de/docs/orca/6.0/manual/contents/detailed/property_file.html
+> - orca_parser (GitHub): https://github.com/avanteijlingen/orca_parser
+> Collected: 2026-06-12
+
+## Output File Structure
+
+ORCA generates several output files. The main output file uses the same BaseName as the input with no extension (or `.out`).
+
+### Primary Output Files
+
+| File | Description |
+|------|-------------|
+| `basename` (no ext) | Main output with full calculation details |
+| `basename.gbw` | Gaussian basis set wavefunction file |
+| `basename.property.txt` | Structured property data |
+| `basename.hess` | Hessian data |
+| `basename.opt` | Optimization trajectory |
+| `basename.xyz` | Final geometry in XYZ format |
+| `basename.engrad` | Energy + gradient data |
+| `basename.inp` | Copy of input file |
+| `basename.cis` | CIS/TD-DFT data |
+| `basename.mp2` | MP2 natural orbitals |
+| `basename.mdcipnoint` | DLPNO integrals |
+| `basename.densities` | Density matrices |
+| `basename.scfp` | SCF density matrix (alpha) |
+| `basename.scfr` | SCF density matrix (beta) |
+
+## Main Output File Sections
+
+### 1. Header
+
+```
+                            *****************
+                            |               |
+                            |      O  R     |
+                            |    C  A  !    |
+                            |               |
+                            *****************
+
+         Program Version 6.1.1 - Release  -  PATH
+
+         based on the original ORCA code by Frank Neese
+```
+
+Includes version, references, and contributors.
+
+### 2. Input Echo
+
+The input file is echoed back for reference.
+
+### 3. Warnings
+
+```
+WARNINGS:
+   [your warnings here]
+```
+
+Should be carefully checked before proceeding.
+
+### 4. Calculation Type Banner
+
+```
+****************************
+* Single Point Calculation *
+****************************
+```
+
+Or:
+
+```
+******************************
+* Geometry Optimization Run  *
+******************************
+```
+
+### 5. Integral Module (SHARK)
+
+```
+----------------------
+SHARK INTEGRAL PACKAGE
+----------------------
+
+Number of atoms                             ...      2
+Number of basis functions                   ...     19
+Number of shells                            ...      9
+Maximum angular momentum                    ...      2
+Integral batch strategy                     ... SHARK/LIBINT Hybrid
+RI-J (if used) integral strategy            ... SPLIT-RIJ
+Printlevel                                  ...      1
+Contraction scheme used                     ... SEGMENTED contraction
+```
+
+### 6. SCF Settings
+
+```
+------------
+SCF SETTINGS
+------------
+Hamiltonian:
+ Ab initio Hamiltonian  Method          .... Hartree-Fock(GTOs)
+
+General Settings:
+ Integral files         IntName         .... orca
+ Hartree-Fock type      HFTyp           .... UHF
+ Total Charge           Charge          ....    0
+ Multiplicity           Mult            ....    2
+ Number of atoms        NAtoms          ....    2
+ Number of basis functions NBas         ....   19
+```
+
+### 7. SCF Convergence
+
+Each SCF iteration shows:
+
+```
+ITER  Energy     Delta-E   Max-DP   RMS-DP   [F,P]   Damp
+                (Eh)      (Eh)     (Dp)     (Dp)
+  1   -75.3182  0.0000000 0.15362  0.05697  0.625   0.7000
+  2   -75.3237 -0.0055463 0.08961  0.03241  0.354   0.0000
+  ...
+ 11   -75.3242 -0.0000000 0.00000  0.00000  0.000   0.0000
+```
+
+On convergence:
+
+```
+               *****************************************************
+               *                     SUCCESS                       *
+               *           SCF CONVERGED AFTER  11 CYCLES          *
+               *****************************************************
+```
+
+### 8. Total Energy
+
+```
+----------------
+TOTAL SCF ENERGY
+----------------
+
+Total Energy       :        -75.32415421767207 Eh           -2049.67444 eV
+
+Components:
+Nuclear Repulsion  :          4.27488404160356 Eh             116.32551 eV
+Electronic Energy  :        -79.59903825927563 Eh           -2165.99995 eV
+One Electron Energy:       -112.46709636116736 Eh           -3060.38528 eV
+Two Electron Energy:         32.86805810189173 Eh             894.38533 eV
+```
+
+### 9. Orbital Energies
+
+```
+ORBITAL ENERGIES
+
+   NO   OCC          E(Eh)            E(eV)
+    0   1.0000     -20.254374       -551.3268
+    1   1.0000      -1.254987        -34.1581
+    2   1.0000      -0.612752        -16.6771
+    3   1.0000      -0.453448        -12.3423
+    4   1.0000      -0.391560        -10.6572
+    5   0.0000       0.148932          4.0546
+```
+
+### 10. Final Single Point Energy
+
+```
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -75.324154217672
+-------------------------   --------------------
+```
+
+This is the key line to parse for the computed energy.
+
+### 11. Dipole Moment
+
+```
+DIPOLE MOMENT
+                                 X             Y             Z
+Total Dipole Moment:      0.00000      -0.00000       1.49445
+Magnitude (a.u.):            1.49445
+Magnitude (Debye):           3.79579
+```
+
+### 12. Population Analysis
+
+```
+MULLIKEN ATOMIC CHARGES
+   0 O:    -0.402345
+   1 H:     0.201173
+   2 H:     0.201173
+Sum of atomic charges:    0.0000
+```
+
+### 13. Timings
+
+```
+Timings:
+Reading and initializing          ...     0.004 sec
+Integral generation               ...     0.007 sec
+SCF iterations                    ...     0.038 sec
+  Coulomb evaluation              ...     0.020 sec
+  HF-exchange                     ...     0.000 sec
+  XC-evaluation                   ...     0.000 sec
+  DIIS step                       ...     0.003 sec
+  Orbital orthonormalization      ...     0.001 sec
+TOTAL                             ...     0.049 sec
+```
+
+## Geometry Optimization Output
+
+### Optimization Header
+
+```
+******************************
+* GEOMETRY OPTIMIZATION CYCLE *
+******************************
+```
+
+### Per-Cycle Energy
+
+```
+                          ~!!!!!!!!!!!!!!!
+                          ~ FINAL ENERGY ~
+                          ~!!!!!!!!!!!!!!!
+                      Ecorr =     -75.324154210 Eh
+                      DE   =         -0.000000000 Eh
+```
+
+### Convergence Criteria
+
+```
+Geometry convergence  criteria:
+Energy change              0.0000050   [Eh]     ****  YES
+Max. gradient              0.0004500   [Eh/bohr] NO
+RMS gradient               0.0003000   [Eh/bohr] YES
+Max. displacement          0.0018000   [bohr]    NO
+RMS displacement           0.0012000   [bohr]    YES
+```
+
+### Convergence Summary
+
+```
+                       *****************************************************
+                       *                     SUCCESS                       *
+                       *         GEOMETRY OPTIMIZATION CONVERGED           *
+                       *****************************************************
+```
+
+## Frequency Calculation Output
+
+### Vibrational Frequencies
+
+```
+VIBRATIONAL FREQUENCIES
+
+   0:       0.00 cm**-1
+   1:       0.00 cm**-1
+   2:       0.00 cm**-1
+   3:       0.00 cm**-1
+   4:       0.00 cm**-1
+   5:       0.00 cm**-1
+   6:    1594.78 cm**-1
+   7:    3657.04 cm**-1
+   8:    3755.62 cm**-1
+```
+
+### Thermochemistry
+
+```
+--------------------
+THERMOCHEMISTRY
+--------------------
+
+Temperature         ... 298.15 K
+Pressure            ... 1.00 atm
+Total Mass          ... 18.015 AMU
+
+Electronic energy   ...    -76.01915435 Eh
+Zero-point energy   ...      0.02134532 Eh     13.41 kcal/mol
+Thermal energy      ...      0.02417856 Eh     15.19 kcal/mol
+```
+
+## TD-DFT Output
+
+### Excited States
+
+```
+-----------------------------
+TD-DFT/TDA EXCITATION SPECTRA
+-----------------------------
+
+STATE  1:  E=   0.148932 au      4.055 eV    32714.2 cm**-1
+     49 ->  50  :     0.9898 (c=  0.994860)
+     49 ->  52  :    -0.0951 (c= -0.097522)
+
+STATE  2:  E=   0.234567 au      6.386 eV    51534.1 cm**-1
+     48 ->  50  :     0.9712 (c=  0.985503)
+```
+
+## Property File Format
+
+ORCA generates a `basename.property.txt` file with structured key-value data suitable for programmatic parsing:
+
+```
+# Number of atoms
+$number_of_atoms
+6
+
+# Total Charge
+$total_charge
+0
+
+# Spin multiplicity
+$spin_multiplicity
+1
+
+# Total Energy (Eh)
+$total_energy
+-232.178932
+
+# Final Single Point Energy (Eh)
+$final_single_point_energy
+-232.178932
+```
+
+## Key Parsing Patterns
+
+### Final Energy
+Search for: `FINAL SINGLE POINT ENERGY`
+
+### SCF Convergence
+Search for: `SCF CONVERGED AFTER`
+
+### Optimization Convergence
+Search for: `GEOMETRY OPTIMIZATION CONVERGED`
+
+### Frequencies
+Search for: `VIBRATIONAL FREQUENCIES`
+
+### Excited States
+Search for: `TD-DFT/TDA EXCITATION` or `TD-DFT EXCITATION`
+
+### Dipole Moment
+Search for: `DIPOLE MOMENT` or `Total Dipole Moment`
+
+### Charges
+Search for: `MULLIKEN ATOMIC CHARGES` or `LOEWDIN ATOMIC CHARGES`

--- a/raw/assets/orca-tutorials.md
+++ b/raw/assets/orca-tutorials.md
@@ -1,0 +1,219 @@
+# ORCA Tutorials and Learning Resources
+
+> Sources:
+> - ORCA 6.0 Tutorials (FACCTs): https://www.faccts.de/docs/orca/6.0/tutorials/
+> - ORCA Input Library: https://sites.google.com/site/orcainputlibrary/home
+> - Texas A&M HPRC: https://hprc.tamu.edu/training/intro_orca.html
+> - Winter School ORCA Intro: https://winterschool.cc/images/ORCAIntro_WSCC_2021.pdf
+> Collected: 2026-06-12
+
+## Official Resources
+
+### ORCA 6.0 Tutorials (FACCTs)
+- URL: https://www.faccts.de/docs/orca/6.0/tutorials/
+- Official tutorials aimed at new users.
+
+**Tutorial Sections:**
+
+#### First Steps
+- How to cite
+- Installing ORCA
+- Hello water! Your first ORCA calculation
+- Input and Output
+- Running a calculation in parallel
+- Graphical User Interfaces (GUI)
+- Solving common issues
+
+#### Workflows
+- Compound Jobs
+- Extrapolation Techniques
+
+#### Properties
+- Single point energies
+- Geometry optimization
+- Vibrational frequencies
+- Thermodynamics
+- Implicit Solvation Models
+- Explicit Solvation (SOLVATOR)
+- Conformer Search (GOAT)
+- Relativistic corrections
+- Dispersion corrections
+- Bond Analysis
+- Local Energy Decomposition (LED)
+- Fractional occupation density (FOD)
+- Charge Models
+
+#### Reactivity
+- Finding Transition States with NEB-TS
+- Transition State Conformers
+- Intrinsic Reaction Coordinate (IRC)
+- Calculating accurate energy barriers
+- Kinetic Isotope Effects (KIE)
+- Plotting Fukui functions
+- Automated docking (DOCKER)
+
+#### Spectroscopy
+- Infrared and Raman
+- UV/Vis spectroscopy
+- Electronic Circular Dichroism (ECD)
+- Vibrational Circular Dichroism (VCD)
+- Nuclear Magnetic Resonance (NMR)
+- Electron Paramagnetic Resonance (EPR)
+- Spin-orbit coupling
+
+#### Multiscale Methods
+- QM/XTB ONIOM
+- ONIOM methods beyond QM/XTB
+- Multiscale NEB-TS for transition states
+- Ionic-Crystal-QM/MM
+
+### ORCA 6.1.1 Manual
+- URL: https://orca-manual.mpi-muelheim.mpg.de/
+- The most comprehensive reference for all ORCA features.
+- Organized into major sections:
+
+**Manual Table of Contents:**
+1. Quickstart Guide
+2. Essential Calculation Elements
+   - General Structure of Input File
+   - Input of Coordinates
+   - Basic Calculation Settings
+   - Control of Output
+   - Parallel and Multi-Process Runs
+   - Self-Consistent-Field (SCF)
+   - Basis Sets
+   - Resolution-of-the-Identity (RI)
+   - Numerical Integration
+   - Counterpoise Corrections
+   - Relativistic Calculations
+   - Implicit Solvation
+3. Model Chemistries
+   - Wavefunction Types
+   - Hartree-Fock Theory
+   - DFT
+   - Dispersion Corrections
+   - Semiempirical Methods
+   - Composite Methods (3c)
+   - MP2
+   - Coupled Cluster (MDCI)
+   - CASSCF and RAS/ORMAS
+   - ICE-CI
+   - DMRG
+   - NEVPT2, CASPT2
+   - MR-EOM-CC
+4. Structure and Reactivity
+   - Geometry Optimizations
+   - Surface Scans
+   - Transition State Searches
+   - IRC
+   - NEB Method
+   - Vibrational Frequencies
+   - Thermochemistry
+   - GOAT, SOLVATOR, DOCKER
+5. Spectroscopy and Properties
+   - Population Analysis
+   - NBO Analysis
+   - Excited States (TD-DFT, ROCIS, EOM-CCSD, etc.)
+   - Vibrational Spectroscopy
+   - NMR, EPR Parameters
+   - Mossbauer Parameters
+   - Spin-Orbit Coupling
+   - Local Energy Decomposition
+6. Multiscale Simulations
+7. Molecular Dynamics
+8. Workflows and Automatization
+   - ORCA Python Interface (OPI)
+   - Compound Module
+   - Compound Examples
+9. Utilities and Visualization
+   - Orbital/Density Plots
+   - orca_2JSON
+   - Property File
+
+## Community Resources
+
+### ORCA Input Library
+- URL: https://sites.google.com/site/orcainputlibrary/home
+- Community-maintained collection of ORCA input files.
+- Note: Not updated for ORCA 6.0 yet. Maintainer seeks help.
+
+**Pages available:**
+- Setting up ORCA
+- ORCA Common Errors and Problems
+- General Input
+- Restarting calculations
+- Geometry input
+- Visualization and printing
+- Basis sets
+- Effective Core Potentials
+- Numerical precision
+- SCF Convergence Issues
+- Semiempirical methods
+- DFT calculations
+- MP2 & MP3
+- Relativistic approximations
+- Geometry optimizations
+- Vibrational Frequencies & Thermochemistry
+- Molecular properties
+- Frozen core calculations
+- Coupled cluster
+- Excited state calculations
+- CASSCF calculations
+- Interfaces and QM/MM
+- Orbital and density analysis
+- Continuum solvation (CPCM, COSMO, SMD)
+- Useful scripts and commands for ORCA I/O
+- Molecular dynamics
+
+### Texas A&M HPRC Tutorial
+- URL: https://hprc.tamu.edu/training/intro_orca.html
+- PDF: https://hprc.tamu.edu/files/training/2020/Fall/Intro_ORCA_tutorial.pdf
+- Brief introduction to quantum chemistry simulations with ORCA.
+- Covers input file structure, running jobs, and basic analysis.
+
+### Winter School ORCA Introduction
+- URL: https://winterschool.cc/images/ORCAIntro_WSCC_2021.pdf
+- Lecture slides covering ORCA basics.
+- Includes geometry optimizations, DFT, basis sets, and practical examples.
+
+### Zipse Group ORCA Input Files
+- URL: https://zipse.cup.uni-muenchen.de/teaching/computational-chemistry-2/topics/orca-input-files/
+- Practical examples of ORCA input files from a university course.
+
+## Video Tutorials
+
+### Official/Recommended
+- **How to Download, Install & Run ORCA**: https://www.youtube.com/watch?v=zrct4Xa-Jdg
+- **H2O Geometry Optimization**: https://www.youtube.com/watch?v=onU2vPIGunE
+- **Compound Module Tutorial**: https://www.youtube.com/watch?v=6Hk4pDk0vLM
+- **ORCA-Python Interface (OPI)**: https://www.youtube.com/watch?v=L-_gLevWA2k
+
+### Comprehensive Course
+- **Dr. M. A. Hashmi's YouTube Playlist**: https://www.youtube.com/playlist?list=PLWk-zl-RHnbeS6w418dSucN690VN_j8wA
+- From installation to advanced calculations.
+
+## HPC Documentation
+
+- **NERSC**: https://docs.nersc.gov/applications/orca/
+- **University of Chicago RCC**: https://docs.rcc.uchicago.edu/software/apps-and-envs/orca/
+- **PC2 Paderborn**: https://upb-pc2.atlassian.net/wiki/spaces/PC2DOK/pages/1902859
+- **CSC Finland**: https://github.com/CSCfi/csc-user-guide/blob/master/docs/apps/orca.md
+
+## Chinese-Language Resources
+
+- **Multiwfn ORCA Input Generation**: http://sobereva.com/490
+- **ORCA 5.0 New Features**: http://sobereva.com/604
+- **ORCA Beginner Guide**: https://www.scribd.com/document/690433235/
+
+## Quick Reference Card
+
+For a new ORCA user, the recommended learning path is:
+
+1. **Install ORCA** -- follow the "Installing ORCA" tutorial
+2. **Hello Water** -- run your first calculation
+3. **Input/Output** -- understand file structure
+4. **DFT Optimization** -- learn geometry optimization
+5. **Frequencies** -- verify minima, get thermochemistry
+6. **TD-DFT** -- calculate excited states
+7. **Compound Jobs** -- chain multi-step workflows
+8. **Advanced Methods** -- DLPNO-CCSD(T), CASSCF, etc.

--- a/wiki/concepts/Compound_Jobs.md
+++ b/wiki/concepts/Compound_Jobs.md
@@ -1,0 +1,112 @@
+# 复合作业与工作流 / Compound Jobs and Workflows
+
+> 类型：概念 / Concept
+> 创建日期：2026-06-12
+> 来源数：3
+
+## 核心概念 / Core Concept
+
+ORCA支持在单个输入文件中执行多步计算（复合作业），允许串联不同方法和基组的计算步骤。这是实现高效量子化学工作流的关键特性。
+
+## 实现方式 / Implementation Methods
+
+### 1. 组合关键字（推荐用于简单场景）
+
+最简单的方式是在`!`行中组合多个作业类型：
+
+```orca
+! B3LYP def2-TZVP OPT FREQ D3BJ
+```
+
+这会先优化几何，再计算频率。
+
+### 2. $new_job 分隔符（已弃用但仍可用）
+
+用`$new_job`分隔多个独立计算步骤：
+
+```orca
+# 步骤1：廉价优化
+! B3LYP def2-SVP OPT TightSCF
+* xyz 0 1
+  O 0 0 0
+  H 0 0 1
+  H 0 1 0
+*
+
+$new_job
+
+# 步骤2：高精度单点
+! DLPNO-CCSD(T) def2-TZVPP def2-TZVPP/C TightSCF
+```
+
+**注意**：`$new_job`已弃用，ORCA推荐使用Compound模块。
+
+### 3. Compound 模块（推荐用于复杂场景）
+
+ORCA 6.x引入的Compound模块提供Python风格的脚本化工作流：
+
+- 支持变量传递和条件逻辑
+- 官方脚本库: https://github.com/ORCAQuantumChemistry/CompoundScripts
+- 详见ORCA手册8.2-8.4节
+
+### 4. ORCA Python Interface (OPI)
+
+ORCA 6.1+提供的完整Python接口：
+
+```python
+# OPI工作流伪代码
+result = run_dft_optimization(geometry)
+sp_energy = run_dlpno_ccsdt(result.geometry)
+```
+
+## 常见工作流模式 / Common Workflow Patterns
+
+### 模式1：廉价优化 + 高精度单点
+
+| 步骤 | 方法 | 基组 | 目的 |
+|------|------|------|------|
+| 1 | B3LYP | def2-SVP | 几何优化 |
+| 2 | DLPNO-CCSD(T) | def2-TZVPP/C | 高精度能量 |
+
+### 模式2：优化 + 频率 + 激发态
+
+| 步骤 | 方法 | 基组 | 目的 |
+|------|------|------|------|
+| 1 | B3LYP | def2-TZVP | OPT FREQ |
+| 2 | CAM-B3LYP | def2-TZVP | TD-DFT |
+
+### 模式3：CBS外推
+
+| 步骤 | 基组 | 目的 |
+|------|------|------|
+| 1 | def2-TZVPP/C | TZ能量 |
+| 2 | def2-QZVPP/C | QZ能量 |
+| 3 | 外推公式 | CBS能量 |
+
+### 模式4：溶剂化 + 构象搜索
+
+| 步骤 | 方法 | 目的 |
+|------|------|------|
+| 1 | GOAT | 全局构象搜索 |
+| 2 | B3LYP/def2-TZVP + CPCM | 精确优化 |
+
+## $new_job 行为细节 / $new_job Behavior
+
+- 前一步的所有计算标志传递到下一步
+- 只需指定需要更改的设置
+- 默认使用上一步的轨道作为初始猜测
+- 如果不需要继承轨道，需显式指定Guess
+- RI近似等设置也会继承（如不需要需手动关闭）
+
+## 相关来源 / Related Sources
+
+- `raw/assets/orca-compound-jobs.md`
+- ORCA 6.1.1 Manual 8.2-8.4节
+- CompoundScripts GitHub仓库
+
+## 相关实体/概念 / Related Entities/Concepts
+
+- [[Job_Types]]
+- [[Percent_Blocks]]
+- [[Geometry_Optimization]]
+- [[Frequency_Calculation]]

--- a/wiki/entities/Basis_Sets.md
+++ b/wiki/entities/Basis_Sets.md
@@ -87,6 +87,8 @@
 ## 相关来源 / Related Sources
 
 - `src/orca_lsp/keywords.py`：BASIS_SETS字典
+- `raw/assets/orca-basis-sets-reference.md` -- ORCA 6.1.1 Manual Section 2.7, complete basis set reference
+- `raw/assets/orca-keywords-reference.md` -- Keywords reference including basis set keywords
 
 ## 相关实体/概念 / Related Entities/Concepts
 

--- a/wiki/entities/ORCA_GitHub_Tools.md
+++ b/wiki/entities/ORCA_GitHub_Tools.md
@@ -1,0 +1,71 @@
+# ORCA相关工具与解析器 / ORCA-Related Tools and Parsers
+
+> 类型：外部工具 / External Tools
+> 创建日期：2026-06-12
+> 来源数：1
+
+## 简介 / Introduction
+
+围绕ORCA量子化学软件，社区和官方开发了大量工具，涵盖输出解析、输入生成、自动化工作流和机器学习集成。
+
+## 官方工具 / Official Tools
+
+### CompoundScripts
+- GitHub: https://github.com/ORCAQuantumChemistry/CompoundScripts
+- 官方复合作业脚本库，用于自动化复杂计算工作流
+
+### ORCA Python Interface (OPI)
+- 随ORCA 6.1发布
+- 提供Python API用于输入创建、任务执行和输出解析
+- 论文: https://pubs.acs.org/doi/10.1021/acs.jctc.5c02141
+
+### orca_2JSON
+- ORCA内置工具（手册9.3节）
+- 将ORCA输出转换为JSON格式
+
+## 输出解析器 / Output Parsers
+
+### orca_parser (Python)
+- GitHub: https://github.com/avanteijlingen/orca_parser
+- PyPI: `pip install orca-parser`
+- 专门解析ORCA输出文件的Python模块
+
+### cclib
+- URL: https://cclib.github.io/
+- 多格式量子化学解析器，支持ORCA、Gaussian、NWChem等
+- 通过parse-patrol提供MCP服务器接口: https://github.com/ndaelman-hu/parse-patrol
+
+### qccodec
+- GitHub: https://github.com/coltonbh/qccodec
+- 量子化学I/O解析库，编码输入、解码输出为结构化对象
+
+## 自动化工具 / Automation Tools
+
+### ASE ORCA Calculator
+- 文档: https://ase-lib.org/ase/calculators/orca.html
+- 原子模拟环境中的ORCA接口
+- 支持SCF、DFT、MP2、CASSCF、耦合簇
+
+### ASH Framework
+- 文档: https://ash.readthedocs.io/en/latest/ORCA-interface.html
+- 灵活的ORCA接口，处理输入生成、输出解析和数据提取
+
+### Parallelized-DFT-ORCA
+- GitHub: https://github.com/aspuru-guzik-group/Parallelized-DFT-ORCA
+- 自动化完整工作流：优化 -> 频率 -> 激发能 -> NTO分析
+
+## 对orca-lsp的启示 / Implications for orca-lsp
+
+1. **解析模式**: `orca_parser`和`cclib`提供ORCA输出解析的参考实现
+2. **输入验证**: ASE和ASH接口展示如何程序化生成有效ORCA输入
+3. **关键字数据库**: 工具如Multiwfn和qccodec维护的关键字列表可辅助LSP自动补全
+4. **结构化输出**: `orca_2JSON`和`property.txt`提供机器可读输出格式
+
+## 相关来源 / Related Sources
+
+- `raw/assets/orca-github-tools.md`
+
+## 相关实体/概念 / Related Entities/Concepts
+
+- [[ORCA_Quantum_Chemistry]]
+- [[Language_Server_Protocol]]

--- a/wiki/entities/ORCA_Official_Documentation.md
+++ b/wiki/entities/ORCA_Official_Documentation.md
@@ -1,0 +1,86 @@
+# ORCA官方文档资源 / ORCA Official Documentation Resources
+
+> 类型：外部资源 / External Resource
+> 创建日期：2026-06-12
+> 来源数：7
+
+## 简介 / Introduction
+
+ORCA的官方文档分散在多个平台上，包括MPI Mulheim的在线手册、FACCTs的教程和手册、以及社区维护的输入库。本文档汇总了所有关键文档来源。
+
+## 核心文档来源 / Core Documentation Sources
+
+### 1. ORCA 6.1.1 Manual (MPI Mulheim)
+- URL: https://orca-manual.mpi-muelheim.mpg.de/
+- 最全面的ORCA参考文档
+- 包含所有输入格式、方法、基组、性质的详细说明
+- 主要章节：
+  - Quickstart Guide
+  - Essential Calculation Elements (输入文件结构、基组、RI、SCF等)
+  - Model Chemistries (DFT、MP2、CCSD(T)、CASSCF等)
+  - Structure and Reactivity (优化、过渡态、频率等)
+  - Spectroscopy and Properties (TD-DFT、NMR、EPR等)
+  - Workflows and Automatization (Compound、OPI)
+
+### 2. ORCA 6.0 Tutorials (FACCTs)
+- URL: https://www.faccts.de/docs/orca/6.0/tutorials/
+- 面向新用户的交互式教程
+- 覆盖：安装、输入输出、并行计算、DFT、优化、频率、TD-DFT、溶剂化、过渡态
+
+### 3. ORCA 6.0 Manual (FACCTs)
+- URL: https://www.faccts.de/docs/orca/6.0/manual/
+- PDF下载: https://www.faccts.de/docs/orca/6.0/manual/_downloads/f5a34d500b44971b2b057d96d7f899ca/orca.pdf
+- 离线可用的完整手册
+
+### 4. ORCA Input Library (社区维护)
+- URL: https://sites.google.com/site/orcainputlibrary/home
+- 由Ragnar Bjornsson维护的ORCA输入文件示例库
+- 页面包括：DFT计算、几何优化、频率、TD-DFT、耦合簇、CPCM、SCF收敛等
+- 注意：尚未更新至ORCA 6.0
+
+### 5. CompoundScripts (GitHub)
+- URL: https://github.com/ORCAQuantumChemistry/CompoundScripts
+- ORCA官方GitHub组织提供的自动化脚本库
+- 包含复合作业、外推技术、自动化工作流示例
+
+### 6. ORCA Forum
+- 由ORCA团队直接管理的用户论坛
+- 用于提交问题和报告bug
+
+### 7. ORCA Python Interface (OPI)
+- 论文: https://pubs.acs.org/doi/10.1021/acs.jctc.5c02141
+- ORCA 6.1+提供的Python接口
+- 支持输入创建、任务执行和输出解析
+
+## 教程与学习资源 / Tutorials and Learning Resources
+
+### HPC文档
+- NERSC: https://docs.nersc.gov/applications/orca/
+- University of Chicago RCC: https://docs.rcc.uchicago.edu/software/apps-and-envs/orca/
+- Texas A&M HPRC: https://hprc.tamu.edu/training/intro_orca.html
+- CSC Finland: https://github.com/CSCfi/csc-user-guide/blob/master/docs/apps/orca.md
+
+### 学术讲座
+- Winter School ORCA Intro: https://winterschool.cc/images/ORCAIntro_WSCC_2021.pdf
+- Pantazis DFT-BasisSets Lecture: https://pc2.uni-paderborn.de/fileadmin/pc2/events/2020-02-10_Winterschool/Pantazis_DFT-BasisSets.pdf
+- Ragnar Bjornsson ORCA Talk: https://pc2.uni-paderborn.de/fileadmin/pc2/events/2020-02-10_Winterschool/RagnarBjornsson-Paderborn-ORCAtalk.pdf
+
+### 中文资源
+- Multiwfn ORCA输入生成: http://sobereva.com/490
+- ORCA 5.0新特性: http://sobereva.com/604
+
+## 相关来源 / Related Sources
+
+- `raw/assets/orca-input-format.md`
+- `raw/assets/orca-keywords-reference.md`
+- `raw/assets/orca-examples.md`
+- `raw/assets/orca-output-format.md`
+- `raw/assets/orca-tutorials.md`
+- `raw/assets/orca-compound-jobs.md`
+- `raw/assets/orca-basis-sets-reference.md`
+- `raw/assets/orca-github-tools.md`
+
+## 相关实体/概念 / Related Entities/Concepts
+
+- [[ORCA_Quantum_Chemistry]]
+- [[Input_File_Guide]] (wiki/synthesis/)

--- a/wiki/entities/ORCA_Quantum_Chemistry.md
+++ b/wiki/entities/ORCA_Quantum_Chemistry.md
@@ -41,6 +41,10 @@ ORCA输入文件使用`.inp`扩展名，包含三个主要部分：
 - `raw/assets/docs/ARCHITECTURE.md`
 - `raw/assets/examples/water.inp`
 - `raw/assets/examples/benzene.inp`
+- `raw/assets/orca-input-format.md` -- ORCA 6.1.1 Manual Section 2.1
+- `raw/assets/orca-keywords-reference.md` -- Keywords, methods, basis sets, job types
+- `raw/assets/orca-tutorials.md` -- ORCA tutorials and learning resources
+- `raw/assets/orca-github-tools.md` -- GitHub ORCA tools and parsers
 
 ## 相关实体/概念 / Related Entities/Concepts
 

--- a/wiki/entities/Percent_Blocks.md
+++ b/wiki/entities/Percent_Blocks.md
@@ -2,7 +2,7 @@
 
 > 类型：参数块 / Parameter Block
 > 创建日期：2026-06-12
-> 来源数：1
+> 来源数：3
 
 ## 简介 / Introduction
 

--- a/wiki/synthesis/Input_File_Guide.md
+++ b/wiki/synthesis/Input_File_Guide.md
@@ -272,3 +272,8 @@ end
 - `raw/assets/examples/benzene.inp`
 - `raw/assets/examples/td_dft.inp`
 - `raw/assets/examples/solvation.inp`
+- `raw/assets/orca-input-format.md` -- ORCA 6.1.1 Manual Section 2.1 (official input format)
+- `raw/assets/orca-keywords-reference.md` -- Comprehensive keyword reference
+- `raw/assets/orca-examples.md` -- 18 example input files with annotations
+- `raw/assets/orca-compound-jobs.md` -- Multi-step workflow patterns
+- ORCA 6.0 Tutorials: https://www.faccts.de/docs/orca/6.0/tutorials/first_steps/input_output.html

--- a/wiki/synthesis/ORCA_Output_Guide.md
+++ b/wiki/synthesis/ORCA_Output_Guide.md
@@ -1,0 +1,108 @@
+# ORCA输出文件解析指南 / ORCA Output File Parsing Guide
+
+> 创建日期：2026-06-12
+> 最后更新：2026-06-12
+> 覆盖来源：4
+
+## 核心论点 / Core Argument
+
+ORCA生成多种输出文件，主输出文件包含详细的人类可读计算信息，`property.txt`提供结构化的机器可读数据。理解输出文件结构对于验证计算结果和开发解析工具至关重要。
+
+## 输出文件类型 / Output File Types
+
+| 文件 | 扩展名/格式 | 用途 |
+|------|-----------|------|
+| 主输出 | 无扩展名 | 完整计算细节 |
+| 波函数 | `.gbw` | 轨道和密度矩阵 |
+| 性质 | `.property.txt` | 结构化关键数据 |
+| Hessian | `.hess` | Hessian矩阵数据 |
+| 优化轨迹 | `.opt` | 优化步骤几何 |
+| 最终几何 | `.xyz` | XYZ格式几何 |
+| 能量+梯度 | `.engrad` | 能量和梯度向量 |
+
+## 主输出文件关键段 / Key Output Sections
+
+### 1. 总能量 (FINAL SINGLE POINT ENERGY)
+```
+-------------------------   --------------------
+FINAL SINGLE POINT ENERGY       -75.324154217672
+-------------------------   --------------------
+```
+
+### 2. SCF收敛
+```
+               *           SCF CONVERGED AFTER  11 CYCLES          *
+```
+
+### 3. 优化收敛
+```
+               *         GEOMETRY OPTIMIZATION CONVERGED           *
+```
+
+### 4. 振动频率
+```
+VIBRATIONAL FREQUENCIES
+   6:    1594.78 cm**-1
+```
+
+### 5. 激发态
+```
+STATE  1:  E=   0.148932 au      4.055 eV    32714.2 cm**-1
+```
+
+### 6. 偶极矩
+```
+Total Dipole Moment:      0.00000      -0.00000       1.49445
+Magnitude (Debye):           3.79579
+```
+
+## 解析策略 / Parsing Strategies
+
+### 基于关键字的解析
+
+| 目标数据 | 搜索关键字 | 解析方式 |
+|----------|-----------|---------|
+| 最终能量 | `FINAL SINGLE POINT ENERGY` | 提取后续浮点数 |
+| SCF收敛 | `SCF CONVERGED AFTER` | 提取迭代次数 |
+| 频率 | `VIBRATIONAL FREQUENCIES` | 逐行读取频率值 |
+| 激发态 | `TD-DFT/TDA EXCITATION` | 解析STATE块 |
+| 电荷 | `MULLIKEN ATOMIC CHARGES` | 逐行读取电荷值 |
+
+### 使用 property.txt
+
+ORCA自动生成结构化的property.txt文件，包含以`$`标记的关键字-值对：
+
+```
+$total_energy
+-232.178932
+
+$final_single_point_energy
+-232.178932
+```
+
+### 使用 orca_2JSON
+
+ORCA内置的JSON转换工具（手册9.3节），生成标准JSON格式输出。
+
+## 外部解析工具 / External Parsing Tools
+
+| 工具 | 语言 | 安装 | 特点 |
+|------|------|------|------|
+| orca_parser | Python | `pip install orca-parser` | 专用ORCA解析 |
+| cclib | Python | `pip install cclib` | 多格式支持 |
+| qccodec | Python | `pip install qccodec` | 结构化数据对象 |
+| ASE | Python | `pip install ase` | 完整模拟环境 |
+
+## 对LSP的启示 / Implications for LSP
+
+理解输出文件结构有助于：
+1. **诊断信息映射**：将ORCA警告和错误映射到LSP诊断
+2. **智能提示**：基于常见输出模式提供输入建议
+3. **验证反馈**：解析输出以验证输入文件正确性
+
+## 来源列表 / Source List
+
+- `raw/assets/orca-output-format.md`
+- ORCA 6.0 Tutorials Input/Output页面
+- ORCA 6.1.1 Manual Property File章节
+- orca_parser GitHub仓库


### PR DESCRIPTION
## Summary
Comprehensive ORCA documentation expansion with 8 new raw sources and 4 new wiki pages.

### Raw Assets (8 files)
- orca-input-format.md — Full input file structure from ORCA 6.1.1 Manual
- orca-keywords-reference.md — HF, 17+ DFT functionals, wavefunction methods, basis sets
- orca-examples.md — 18 annotated example input files
- orca-output-format.md — Output sections, optimization, frequency, TD-DFT parsing
- orca-compound-jobs.md — Multi-step workflow documentation
- orca-basis-sets-reference.md — Complete basis set tables (def2, Pople, Dunning, etc.)
- orca-github-tools.md — External tools catalog (cclib, ASE, OPI, etc.)
- orca-tutorials.md — Learning resources and documentation index

### Wiki Pages (4 new + 5 updated)
- New: ORCA_Official_Documentation, ORCA_GitHub_Tools, Compound_Jobs, ORCA_Output_Guide
- Updated: ORCA_Quantum_Chemistry, Basis_Sets, Percent_Blocks, Input_File_Guide, index.md

18 files changed, 2451 insertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)