### PR TITLE
[ORCA] Align package version and close release provenance tag gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "orca-lsp"
-version = "0.5.4"
+version = "0.5.5"
 description = "Language Server Protocol for ORCA quantum chemistry software"
 readme = "README.md"
 license = "MIT"

--- a/src/orca_lsp/__init__.py
+++ b/src/orca_lsp/__init__.py
@@ -5,4 +5,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("orca-lsp")
 except PackageNotFoundError:  # pragma: no cover - only used from an unpackaged source tree
-    __version__ = "0.5.4"
+    __version__ = "0.5.5"

--- a/tests/test_closed_loop_release.py
+++ b/tests/test_closed_loop_release.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 from orca_lsp.agent_operations import operation_path
@@ -75,6 +76,13 @@ class TestReleaseProvenance:
         capabilities = json.loads(Path("lsp-capabilities.json").read_text(encoding="utf-8"))
         assert version_text == capabilities["version"]
         assert capabilities["release_provenance"]["version_file"] == "VERSION"
+
+    def test_pyproject_version_matches_version_file(self) -> None:
+        version_text = Path("VERSION").read_text(encoding="utf-8").strip()
+        pyproject_text = Path("pyproject.toml").read_text(encoding="utf-8")
+        match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject_text, re.MULTILINE)
+        assert match is not None, "Expected project.version in pyproject.toml"
+        assert match.group(1) == version_text
 
     def test_capabilities_fixture_matches_repo_manifest(self) -> None:
         repo = json.loads(Path("lsp-capabilities.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- Bump `pyproject.toml` and the unpackaged `__version__` fallback from `0.5.4` to `0.5.5` so package metadata matches `VERSION`, `CHANGELOG.md`, and `lsp-capabilities.json`.
- Add a regression test ensuring `pyproject.toml` project version stays aligned with the `VERSION` file for OpenQC provenance checks.

Fixes #95

## Test Plan

- [x] `make install` (via local `.venv`)
- [ ] `make format` — fails pre-existing: `scripts/format.sh: line 28: python_format_targets: command not found`
- [x] `make lint` — no linter configured; skipped
- [x] `make typecheck` — mypy success (python_version warning only)
- [x] `make test` — 792 passed, 8 skipped
- [x] `make check` — lint/typecheck/test pass

## Release tag follow-up (do not push from this PR)

After merge and release approval, create the semver tag on the merge commit:

```bash
git tag v0.5.5 <merge-commit-sha>
git push origin v0.5.5
```

This should clear the remaining OpenQC `No git tags found` provenance warning once the tag exists on the release point.

Made with [Cursor](https://cursor.com)
