### PR TITLE
feat: add OpenQC v1 docstring/wiki/raw traceability pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ htmlcov/
 .dmypy.json
 dmypy.json
 .worktrees/
+
+# UV
+uv.lock
+.venv/

--- a/raw/assets/manifest.json
+++ b/raw/assets/manifest.json
@@ -1,0 +1,157 @@
+{
+  "entries": [
+    {
+      "path": "CHANGELOG.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/CHANGELOG.md",
+      "stable_id": "raw-assets-CHANGELOG-md"
+    },
+    {
+      "path": "DEVELOPMENT.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/DEVELOPMENT.md",
+      "stable_id": "raw-assets-DEVELOPMENT-md"
+    },
+    {
+      "path": "README.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/README.md",
+      "stable_id": "raw-assets-README-md"
+    },
+    {
+      "path": "docs/ARCHITECTURE.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/docs/ARCHITECTURE.md",
+      "stable_id": "raw-assets-docs-ARCHITECTURE-md"
+    },
+    {
+      "path": "docs/CONTRIBUTING.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/docs/CONTRIBUTING.md",
+      "stable_id": "raw-assets-docs-CONTRIBUTING-md"
+    },
+    {
+      "path": "docs/DIAGNOSTIC_ENGINE_V1.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/docs/DIAGNOSTIC_ENGINE_V1.md",
+      "stable_id": "raw-assets-docs-DIAGNOSTIC_ENGINE_V1-md"
+    },
+    {
+      "path": "docs/OPENQC_ALIGNMENT.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/docs/OPENQC_ALIGNMENT.md",
+      "stable_id": "raw-assets-docs-OPENQC_ALIGNMENT-md"
+    },
+    {
+      "path": "docs/USER_GUIDE.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/docs/USER_GUIDE.md",
+      "stable_id": "raw-assets-docs-USER_GUIDE-md"
+    },
+    {
+      "path": "docs/agent-verification-loop.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/docs/agent-verification-loop.md",
+      "stable_id": "raw-assets-docs-agent-verification-loop-md"
+    },
+    {
+      "path": "examples/benzene.inp",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/examples/benzene.inp",
+      "stable_id": "raw-assets-examples-benzene-inp"
+    },
+    {
+      "path": "examples/camb3lyp.inp",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/examples/camb3lyp.inp",
+      "stable_id": "raw-assets-examples-camb3lyp-inp"
+    },
+    {
+      "path": "examples/counterpoise.inp",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/examples/counterpoise.inp",
+      "stable_id": "raw-assets-examples-counterpoise-inp"
+    },
+    {
+      "path": "examples/ethylene.inp",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/examples/ethylene.inp",
+      "stable_id": "raw-assets-examples-ethylene-inp"
+    },
+    {
+      "path": "examples/solvation.inp",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/examples/solvation.inp",
+      "stable_id": "raw-assets-examples-solvation-inp"
+    },
+    {
+      "path": "examples/td_dft.inp",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/examples/td_dft.inp",
+      "stable_id": "raw-assets-examples-td_dft-inp"
+    },
+    {
+      "path": "examples/transition_state.inp",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/examples/transition_state.inp",
+      "stable_id": "raw-assets-examples-transition_state-inp"
+    },
+    {
+      "path": "examples/water.inp",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/examples/water.inp",
+      "stable_id": "raw-assets-examples-water-inp"
+    },
+    {
+      "path": "orca-basis-sets-reference.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-basis-sets-reference.md",
+      "stable_id": "raw-assets-orca-basis-sets-reference-md"
+    },
+    {
+      "path": "orca-compound-jobs.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-compound-jobs.md",
+      "stable_id": "raw-assets-orca-compound-jobs-md"
+    },
+    {
+      "path": "orca-examples.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-examples.md",
+      "stable_id": "raw-assets-orca-examples-md"
+    },
+    {
+      "path": "orca-github-tools.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-github-tools.md",
+      "stable_id": "raw-assets-orca-github-tools-md"
+    },
+    {
+      "path": "orca-input-format.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-input-format.md",
+      "stable_id": "raw-assets-orca-input-format-md"
+    },
+    {
+      "path": "orca-keywords-reference.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-keywords-reference.md",
+      "stable_id": "raw-assets-orca-keywords-reference-md"
+    },
+    {
+      "path": "orca-output-format.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-output-format.md",
+      "stable_id": "raw-assets-orca-output-format-md"
+    },
+    {
+      "path": "orca-tutorials.md",
+      "source_type": "raw_asset",
+      "source_url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-tutorials.md",
+      "stable_id": "raw-assets-orca-tutorials-md"
+    }
+  ],
+  "manifest_version": "1.0.0",
+  "repository": "newtontech/orca-lsp",
+  "schema_version": "provenance-manifest-v1"
+}

--- a/reports/docstring-wiki-raw-traceability.json
+++ b/reports/docstring-wiki-raw-traceability.json
@@ -1,0 +1,637 @@
+{
+  "docstrings": [
+    {
+      "path": "src/orca_lsp/__init__.py",
+      "symbol": "Language_Server_Protocol",
+      "wikiPath": "wiki/entities/Language_Server_Protocol.md"
+    },
+    {
+      "path": "src/orca_lsp/agent_lsp.py",
+      "symbol": "Diagnostic_Engine_v1",
+      "wikiPath": "wiki/entities/Diagnostic_Engine_v1.md"
+    },
+    {
+      "path": "src/orca_lsp/agent_lsp.py",
+      "symbol": "Diagnostics_Catalog",
+      "wikiPath": "wiki/synthesis/Diagnostics_Catalog.md"
+    },
+    {
+      "path": "src/orca_lsp/agent_operations.py",
+      "symbol": "Diagnostic_Engine_v1",
+      "wikiPath": "wiki/entities/Diagnostic_Engine_v1.md"
+    },
+    {
+      "path": "src/orca_lsp/agent_operations.py",
+      "symbol": "Diagnostics_Catalog",
+      "wikiPath": "wiki/synthesis/Diagnostics_Catalog.md"
+    },
+    {
+      "path": "src/orca_lsp/features/__init__.py",
+      "symbol": "ORCA_Quantum_Chemistry",
+      "wikiPath": "wiki/entities/ORCA_Quantum_Chemistry.md"
+    },
+    {
+      "path": "src/orca_lsp/features/agent_api.py",
+      "symbol": "ORCA_LSP_API_Reference",
+      "wikiPath": "wiki/synthesis/ORCA_LSP_API_Reference.md"
+    },
+    {
+      "path": "src/orca_lsp/features/agent_api.py",
+      "symbol": "Geometry_Section",
+      "wikiPath": "wiki/entities/Geometry_Section.md"
+    },
+    {
+      "path": "src/orca_lsp/features/agent_api.py",
+      "symbol": "Percent_Blocks",
+      "wikiPath": "wiki/entities/Percent_Blocks.md"
+    },
+    {
+      "path": "src/orca_lsp/features/agent_api.py",
+      "symbol": "Auxiliary_Basis_Sets",
+      "wikiPath": "wiki/entities/Auxiliary_Basis_Sets.md"
+    },
+    {
+      "path": "src/orca_lsp/features/agent_api.py",
+      "symbol": "Element_Symbols",
+      "wikiPath": "wiki/entities/Element_Symbols.md"
+    },
+    {
+      "path": "src/orca_lsp/features/agent_api.py",
+      "symbol": "Geometry_Optimization",
+      "wikiPath": "wiki/concepts/Geometry_Optimization.md"
+    },
+    {
+      "path": "src/orca_lsp/features/agent_api.py",
+      "symbol": "Diagnostics_Catalog",
+      "wikiPath": "wiki/synthesis/Diagnostics_Catalog.md"
+    },
+    {
+      "path": "src/orca_lsp/features/code_actions.py",
+      "symbol": "Diagnostic_Engine_v1",
+      "wikiPath": "wiki/entities/Diagnostic_Engine_v1.md"
+    },
+    {
+      "path": "src/orca_lsp/features/code_actions.py",
+      "symbol": "Diagnostics_Catalog",
+      "wikiPath": "wiki/synthesis/Diagnostics_Catalog.md"
+    },
+    {
+      "path": "src/orca_lsp/features/code_actions.py",
+      "symbol": "Percent_Blocks",
+      "wikiPath": "wiki/entities/Percent_Blocks.md"
+    },
+    {
+      "path": "src/orca_lsp/features/code_actions.py",
+      "symbol": "Geometry_Section",
+      "wikiPath": "wiki/entities/Geometry_Section.md"
+    },
+    {
+      "path": "src/orca_lsp/features/diagnostic.py",
+      "symbol": "Diagnostics_Catalog",
+      "wikiPath": "wiki/synthesis/Diagnostics_Catalog.md"
+    },
+    {
+      "path": "src/orca_lsp/features/diagnostic.py",
+      "symbol": "Diagnostic_Engine_v1",
+      "wikiPath": "wiki/entities/Diagnostic_Engine_v1.md"
+    },
+    {
+      "path": "src/orca_lsp/features/formatting.py",
+      "symbol": "Input_File_Guide",
+      "wikiPath": "wiki/synthesis/Input_File_Guide.md"
+    },
+    {
+      "path": "src/orca_lsp/features/formatting.py",
+      "symbol": "Language_Server_Protocol",
+      "wikiPath": "wiki/entities/Language_Server_Protocol.md"
+    },
+    {
+      "path": "src/orca_lsp/features/formatting.py",
+      "symbol": "ORCA_Output_Guide",
+      "wikiPath": "wiki/synthesis/ORCA_Output_Guide.md"
+    },
+    {
+      "path": "src/orca_lsp/features/formatting.py",
+      "symbol": "Geometry_Section",
+      "wikiPath": "wiki/entities/Geometry_Section.md"
+    },
+    {
+      "path": "src/orca_lsp/features/formatting.py",
+      "symbol": "Percent_Blocks",
+      "wikiPath": "wiki/entities/Percent_Blocks.md"
+    },
+    {
+      "path": "src/orca_lsp/features/lint.py",
+      "symbol": "Diagnostics_Catalog",
+      "wikiPath": "wiki/synthesis/Diagnostics_Catalog.md"
+    },
+    {
+      "path": "src/orca_lsp/features/lint.py",
+      "symbol": "Geometry_Optimization",
+      "wikiPath": "wiki/concepts/Geometry_Optimization.md"
+    },
+    {
+      "path": "src/orca_lsp/features/navigation.py",
+      "symbol": "Element_Symbols",
+      "wikiPath": "wiki/entities/Element_Symbols.md"
+    },
+    {
+      "path": "src/orca_lsp/features/navigation.py",
+      "symbol": "Input_File_Guide",
+      "wikiPath": "wiki/synthesis/Input_File_Guide.md"
+    },
+    {
+      "path": "src/orca_lsp/features/navigation.py",
+      "symbol": "Percent_Blocks",
+      "wikiPath": "wiki/entities/Percent_Blocks.md"
+    },
+    {
+      "path": "src/orca_lsp/features/navigation.py",
+      "symbol": "Geometry_Section",
+      "wikiPath": "wiki/entities/Geometry_Section.md"
+    },
+    {
+      "path": "src/orca_lsp/features/navigation.py",
+      "symbol": "ORCA_Official_Documentation",
+      "wikiPath": "wiki/entities/ORCA_Official_Documentation.md"
+    },
+    {
+      "path": "src/orca_lsp/features/regression.py",
+      "symbol": "Diagnostics_Catalog",
+      "wikiPath": "wiki/synthesis/Diagnostics_Catalog.md"
+    },
+    {
+      "path": "src/orca_lsp/features/rename.py",
+      "symbol": "Input_File_Guide",
+      "wikiPath": "wiki/synthesis/Input_File_Guide.md"
+    },
+    {
+      "path": "src/orca_lsp/features/rename.py",
+      "symbol": "Auxiliary_Basis_Sets",
+      "wikiPath": "wiki/entities/Auxiliary_Basis_Sets.md"
+    },
+    {
+      "path": "src/orca_lsp/features/rename.py",
+      "symbol": "Geometry_Section",
+      "wikiPath": "wiki/entities/Geometry_Section.md"
+    },
+    {
+      "path": "src/orca_lsp/features/rename.py",
+      "symbol": "Percent_Blocks",
+      "wikiPath": "wiki/entities/Percent_Blocks.md"
+    },
+    {
+      "path": "src/orca_lsp/features/test_runner.py",
+      "symbol": "Geometry_Optimization",
+      "wikiPath": "wiki/concepts/Geometry_Optimization.md"
+    },
+    {
+      "path": "src/orca_lsp/features/test_runner.py",
+      "symbol": "Diagnostic_Engine_v1",
+      "wikiPath": "wiki/entities/Diagnostic_Engine_v1.md"
+    },
+    {
+      "path": "src/orca_lsp/features/test_runner.py",
+      "symbol": "Diagnostics_Catalog",
+      "wikiPath": "wiki/synthesis/Diagnostics_Catalog.md"
+    },
+    {
+      "path": "src/orca_lsp/features/typecheck.py",
+      "symbol": "Diagnostics_Catalog",
+      "wikiPath": "wiki/synthesis/Diagnostics_Catalog.md"
+    },
+    {
+      "path": "src/orca_lsp/features/typecheck.py",
+      "symbol": "Geometry_Optimization",
+      "wikiPath": "wiki/concepts/Geometry_Optimization.md"
+    },
+    {
+      "path": "src/orca_lsp/features/typecheck.py",
+      "symbol": "Auxiliary_Basis_Sets",
+      "wikiPath": "wiki/entities/Auxiliary_Basis_Sets.md"
+    },
+    {
+      "path": "src/orca_lsp/keywords.py",
+      "symbol": "Transition_State_Search",
+      "wikiPath": "wiki/concepts/Transition_State_Search.md"
+    },
+    {
+      "path": "src/orca_lsp/parser.py",
+      "symbol": "Input_File_Guide",
+      "wikiPath": "wiki/synthesis/Input_File_Guide.md"
+    },
+    {
+      "path": "src/orca_lsp/parser.py",
+      "symbol": "Transition_State_Search",
+      "wikiPath": "wiki/concepts/Transition_State_Search.md"
+    },
+    {
+      "path": "src/orca_lsp/parser.py",
+      "symbol": "Percent_Blocks",
+      "wikiPath": "wiki/entities/Percent_Blocks.md"
+    },
+    {
+      "path": "src/orca_lsp/parser.py",
+      "symbol": "Geometry_Section",
+      "wikiPath": "wiki/entities/Geometry_Section.md"
+    },
+    {
+      "path": "src/orca_lsp/preflight.py",
+      "symbol": "Wavefunction_Methods",
+      "wikiPath": "wiki/entities/Wavefunction_Methods.md"
+    },
+    {
+      "path": "src/orca_lsp/preflight.py",
+      "symbol": "Auxiliary_Basis_Sets",
+      "wikiPath": "wiki/entities/Auxiliary_Basis_Sets.md"
+    },
+    {
+      "path": "src/orca_lsp/preflight.py",
+      "symbol": "Percent_Blocks",
+      "wikiPath": "wiki/entities/Percent_Blocks.md"
+    },
+    {
+      "path": "src/orca_lsp/preflight.py",
+      "symbol": "Element_Symbols",
+      "wikiPath": "wiki/entities/Element_Symbols.md"
+    },
+    {
+      "path": "src/orca_lsp/preflight.py",
+      "symbol": "Diagnostics_Catalog",
+      "wikiPath": "wiki/synthesis/Diagnostics_Catalog.md"
+    },
+    {
+      "path": "src/orca_lsp/rich_diagnostics.py",
+      "symbol": "Diagnostic_Engine_v1",
+      "wikiPath": "wiki/entities/Diagnostic_Engine_v1.md"
+    },
+    {
+      "path": "src/orca_lsp/rich_diagnostics.py",
+      "symbol": "Auxiliary_Basis_Sets",
+      "wikiPath": "wiki/entities/Auxiliary_Basis_Sets.md"
+    },
+    {
+      "path": "src/orca_lsp/server.py",
+      "symbol": "Language_Server_Protocol",
+      "wikiPath": "wiki/entities/Language_Server_Protocol.md"
+    },
+    {
+      "path": "src/orca_lsp/server.py",
+      "symbol": "Transition_State_Search",
+      "wikiPath": "wiki/concepts/Transition_State_Search.md"
+    },
+    {
+      "path": "src/orca_lsp/server.py",
+      "symbol": "Percent_Blocks",
+      "wikiPath": "wiki/entities/Percent_Blocks.md"
+    },
+    {
+      "path": "src/orca_lsp/server.py",
+      "symbol": "Auxiliary_Basis_Sets",
+      "wikiPath": "wiki/entities/Auxiliary_Basis_Sets.md"
+    },
+    {
+      "path": "src/orca_lsp/server.py",
+      "symbol": "Basis_Sets",
+      "wikiPath": "wiki/entities/Basis_Sets.md"
+    },
+    {
+      "path": "src/orca_lsp/tool.py",
+      "symbol": "Diagnostic_Engine_v1",
+      "wikiPath": "wiki/entities/Diagnostic_Engine_v1.md"
+    },
+    {
+      "path": "src/orca_lsp/tool.py",
+      "symbol": "Geometry_Optimization",
+      "wikiPath": "wiki/concepts/Geometry_Optimization.md"
+    },
+    {
+      "path": "src/orca_lsp/tool.py",
+      "symbol": "Input_File_Guide",
+      "wikiPath": "wiki/synthesis/Input_File_Guide.md"
+    },
+    {
+      "path": "src/orca_lsp/tool.py",
+      "symbol": "Auxiliary_Basis_Sets",
+      "wikiPath": "wiki/entities/Auxiliary_Basis_Sets.md"
+    },
+    {
+      "path": "src/orca_lsp/tool.py",
+      "symbol": "Diagnostics_Catalog",
+      "wikiPath": "wiki/synthesis/Diagnostics_Catalog.md"
+    },
+    {
+      "path": "src/orca_lsp/tool.py",
+      "symbol": "ORCA_Quantum_Chemistry",
+      "wikiPath": "wiki/entities/ORCA_Quantum_Chemistry.md"
+    },
+    {
+      "path": "src/orca_lsp/validator.py",
+      "symbol": "Element_Symbols",
+      "wikiPath": "wiki/entities/Element_Symbols.md"
+    },
+    {
+      "path": "src/orca_lsp/validator.py",
+      "symbol": "Transition_State_Search",
+      "wikiPath": "wiki/concepts/Transition_State_Search.md"
+    },
+    {
+      "path": "src/orca_lsp/validator.py",
+      "symbol": "Geometry_Section",
+      "wikiPath": "wiki/entities/Geometry_Section.md"
+    },
+    {
+      "path": "src/orca_lsp/validator.py",
+      "symbol": "Basis_Sets",
+      "wikiPath": "wiki/entities/Basis_Sets.md"
+    }
+  ],
+  "generatedAt": "2026-06-15T20:09:32Z",
+  "languageId": "orca",
+  "rawManifest": {
+    "ok": true,
+    "path": "raw/assets/manifest.json"
+  },
+  "repository": "https://github.com/newtontech/orca-lsp",
+  "ruleIds": [
+    {
+      "code": "ORCA-INPUT-SYNTAX-001",
+      "sourcePath": "src/orca_lsp/features/lint.py"
+    },
+    {
+      "code": "ORCA-INPUT-SYNTAX-002",
+      "sourcePath": "src/orca_lsp/features/lint.py"
+    },
+    {
+      "code": "ORCA-INPUT-SYNTAX-003",
+      "sourcePath": "src/orca_lsp/features/lint.py"
+    },
+    {
+      "code": "ORCA-INPUT-SYNTAX-004",
+      "sourcePath": "src/orca_lsp/features/lint.py"
+    },
+    {
+      "code": "ORCA-INPUT-VALIDATION-001",
+      "sourcePath": "src/orca_lsp/features/lint.py"
+    },
+    {
+      "code": "ORCA-INPUT-VALIDATION-002",
+      "sourcePath": "src/orca_lsp/features/lint.py"
+    },
+    {
+      "code": "ORCA-INPUT-VALIDATION-003",
+      "sourcePath": "src/orca_lsp/features/lint.py"
+    },
+    {
+      "code": "ORCA-INPUT-SYNTAX-020",
+      "sourcePath": "src/orca_lsp/features/lint.py"
+    },
+    {
+      "code": "ORCA-INPUT-VALIDATION-020",
+      "sourcePath": "src/orca_lsp/features/lint.py"
+    },
+    {
+      "code": "ORCA-INPUT-SYNTAX-021",
+      "sourcePath": "src/orca_lsp/features/lint.py"
+    },
+    {
+      "code": "ORCA-INPUT-SYNTAX-022",
+      "sourcePath": "src/orca_lsp/features/lint.py"
+    },
+    {
+      "code": "ORCA-INPUT-SYNTAX-023",
+      "sourcePath": "src/orca_lsp/features/lint.py"
+    },
+    {
+      "code": "ORCA-INPUT-SYNTAX-024",
+      "sourcePath": "src/orca_lsp/features/lint.py"
+    },
+    {
+      "code": "ORCA-INPUT-CONFIG-001",
+      "sourcePath": "src/orca_lsp/features/lint.py"
+    },
+    {
+      "code": "ORCA-INPUT-SYNTAX-050",
+      "sourcePath": "src/orca_lsp/features/lint.py"
+    },
+    {
+      "code": "ORCA-INPUT-SYNTAX-051",
+      "sourcePath": "src/orca_lsp/features/lint.py"
+    },
+    {
+      "code": "ORCA-INPUT-CONFIG-002",
+      "sourcePath": "src/orca_lsp/features/lint.py"
+    },
+    {
+      "code": "ORCA-INPUT-CONFIG-003",
+      "sourcePath": "src/orca_lsp/features/lint.py"
+    },
+    {
+      "code": "ORCA-INPUT-CONFIG-020",
+      "sourcePath": "src/orca_lsp/features/lint.py"
+    },
+    {
+      "code": "ORCA-INPUT-CONFIG-021",
+      "sourcePath": "src/orca_lsp/features/lint.py"
+    },
+    {
+      "code": "ORCA-INPUT-TYPE-001",
+      "sourcePath": "src/orca_lsp/features/typecheck.py"
+    },
+    {
+      "code": "ORCA-INPUT-TYPE-002",
+      "sourcePath": "src/orca_lsp/features/typecheck.py"
+    },
+    {
+      "code": "ORCA-INPUT-TYPE-003",
+      "sourcePath": "src/orca_lsp/features/typecheck.py"
+    },
+    {
+      "code": "ORCA-INPUT-SCHEMA-001",
+      "sourcePath": "src/orca_lsp/features/typecheck.py"
+    },
+    {
+      "code": "ORCA-INPUT-SCHEMA-002",
+      "sourcePath": "src/orca_lsp/features/typecheck.py"
+    },
+    {
+      "code": "ORCA-INPUT-TYPE-004",
+      "sourcePath": "src/orca_lsp/features/typecheck.py"
+    }
+  ],
+  "schemaVersion": "openqc.lsp.traceability.v1",
+  "serverId": "orca-lsp",
+  "sourceUrls": [
+    {
+      "rawPath": "raw/assets/CHANGELOG.md",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/CHANGELOG.md"
+    },
+    {
+      "rawPath": "raw/assets/DEVELOPMENT.md",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/DEVELOPMENT.md"
+    },
+    {
+      "rawPath": "raw/assets/README.md",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/README.md"
+    },
+    {
+      "rawPath": "raw/assets/docs/ARCHITECTURE.md",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/docs/ARCHITECTURE.md"
+    },
+    {
+      "rawPath": "raw/assets/docs/CONTRIBUTING.md",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/docs/CONTRIBUTING.md"
+    },
+    {
+      "rawPath": "raw/assets/docs/DIAGNOSTIC_ENGINE_V1.md",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/docs/DIAGNOSTIC_ENGINE_V1.md"
+    },
+    {
+      "rawPath": "raw/assets/docs/OPENQC_ALIGNMENT.md",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/docs/OPENQC_ALIGNMENT.md"
+    },
+    {
+      "rawPath": "raw/assets/docs/USER_GUIDE.md",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/docs/USER_GUIDE.md"
+    },
+    {
+      "rawPath": "raw/assets/docs/agent-verification-loop.md",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/docs/agent-verification-loop.md"
+    },
+    {
+      "rawPath": "raw/assets/examples/benzene.inp",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/examples/benzene.inp"
+    },
+    {
+      "rawPath": "raw/assets/examples/camb3lyp.inp",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/examples/camb3lyp.inp"
+    },
+    {
+      "rawPath": "raw/assets/examples/counterpoise.inp",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/examples/counterpoise.inp"
+    },
+    {
+      "rawPath": "raw/assets/examples/ethylene.inp",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/examples/ethylene.inp"
+    },
+    {
+      "rawPath": "raw/assets/examples/solvation.inp",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/examples/solvation.inp"
+    },
+    {
+      "rawPath": "raw/assets/examples/td_dft.inp",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/examples/td_dft.inp"
+    },
+    {
+      "rawPath": "raw/assets/examples/transition_state.inp",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/examples/transition_state.inp"
+    },
+    {
+      "rawPath": "raw/assets/examples/water.inp",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/examples/water.inp"
+    },
+    {
+      "rawPath": "raw/assets/manifest.json",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/manifest.json"
+    },
+    {
+      "rawPath": "raw/assets/orca-basis-sets-reference.md",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-basis-sets-reference.md"
+    },
+    {
+      "rawPath": "raw/assets/orca-compound-jobs.md",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-compound-jobs.md"
+    },
+    {
+      "rawPath": "raw/assets/orca-examples.md",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-examples.md"
+    },
+    {
+      "rawPath": "raw/assets/orca-github-tools.md",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-github-tools.md"
+    },
+    {
+      "rawPath": "raw/assets/orca-input-format.md",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-input-format.md"
+    },
+    {
+      "rawPath": "raw/assets/orca-keywords-reference.md",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-keywords-reference.md"
+    },
+    {
+      "rawPath": "raw/assets/orca-output-format.md",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-output-format.md"
+    },
+    {
+      "rawPath": "raw/assets/orca-tutorials.md",
+      "url": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-tutorials.md"
+    }
+  ],
+  "summary": {
+    "brokenWikiLinks": 0,
+    "docstringsLinked": 69,
+    "docstringsTotal": 69,
+    "rawManifestFailures": 0,
+    "ruleIdsTotal": 26,
+    "sourceUrlsTotal": 26,
+    "wikiSourcesTotal": 11,
+    "wikiSourcesWithoutRaw": 0
+  },
+  "wikiSources": [
+    {
+      "rawPath": "raw/assets/orca-basis-sets-reference.md",
+      "sourceUrl": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-basis-sets-reference.md",
+      "wikiPath": "wiki/concepts/Basis_Set_Selection.md"
+    },
+    {
+      "rawPath": "raw/assets/orca-compound-jobs.md",
+      "sourceUrl": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-compound-jobs.md",
+      "wikiPath": "wiki/concepts/Compound_Jobs.md"
+    },
+    {
+      "rawPath": "raw/assets/orca-keywords-reference.md",
+      "sourceUrl": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-keywords-reference.md",
+      "wikiPath": "wiki/concepts/Coupled_Cluster_Theory.md"
+    },
+    {
+      "rawPath": "raw/assets/orca-tutorials.md",
+      "sourceUrl": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-tutorials.md",
+      "wikiPath": "wiki/concepts/Solvation_Models.md"
+    },
+    {
+      "rawPath": "raw/assets/docs/DIAGNOSTIC_ENGINE_V1.md",
+      "sourceUrl": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/docs/DIAGNOSTIC_ENGINE_V1.md",
+      "wikiPath": "wiki/entities/Diagnostic_Engine_v1.md"
+    },
+    {
+      "rawPath": "raw/assets/orca-input-format.md",
+      "sourceUrl": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-input-format.md",
+      "wikiPath": "wiki/entities/Geometry_Section.md"
+    },
+    {
+      "rawPath": "raw/assets/docs/ARCHITECTURE.md",
+      "sourceUrl": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/docs/ARCHITECTURE.md",
+      "wikiPath": "wiki/entities/Language_Server_Protocol.md"
+    },
+    {
+      "rawPath": "raw/assets/orca-github-tools.md",
+      "sourceUrl": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-github-tools.md",
+      "wikiPath": "wiki/entities/ORCA_GitHub_Tools.md"
+    },
+    {
+      "rawPath": "raw/assets/README.md",
+      "sourceUrl": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/README.md",
+      "wikiPath": "wiki/entities/ORCA_Quantum_Chemistry.md"
+    },
+    {
+      "rawPath": "raw/assets/docs/OPENQC_ALIGNMENT.md",
+      "sourceUrl": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/docs/OPENQC_ALIGNMENT.md",
+      "wikiPath": "wiki/entities/OpenQC_Alignment.md"
+    },
+    {
+      "rawPath": "raw/assets/orca-output-format.md",
+      "sourceUrl": "https://github.com/newtontech/orca-lsp/blob/main/raw/assets/orca-output-format.md",
+      "wikiPath": "wiki/synthesis/ORCA_Output_Guide.md"
+    }
+  ]
+}

--- a/scripts/generate_traceability_report.py
+++ b/scripts/generate_traceability_report.py
@@ -1,0 +1,700 @@
+#!/usr/bin/env python3
+"""OpenQC v1 docstring/wiki/raw traceability report generator.
+
+Produces reports/docstring-wiki-raw-traceability.json satisfying the
+openqc.lsp.traceability.v1 schema.  The report maps:
+  - Source docstrings → wiki pages (docstrings[])
+  - Wiki pages → raw assets (wikiSources[])
+  - Diagnostic rule codes → rule metadata (ruleIds[])
+  - Raw assets → GitHub source URLs (sourceUrls[])
+  - All raw assets → ok status (rawManifest)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "openqc.lsp.traceability.v1"
+SERVER_ID = "orca-lsp"
+REPOSITORY = "https://github.com/newtontech/orca-lsp"
+LANGUAGE_ID = "orca"
+
+BACKEND = "ORCA"
+FILE_ROLE = "INPUT"
+
+# ── Existing code → OpenQC format mapping ────────────────────────────────────
+# Existing rules use codes like ORCA-E001, TC-W001.
+# We map them to <BACKEND>-<FILE_ROLE>-<CATEGORY>-NNN format.
+LEGACY_CODE_MAP: dict[str, str] = {
+    # ORCA lint rules
+    "ORCA-E001": f"{BACKEND}-{FILE_ROLE}-SYNTAX-001",
+    "ORCA-E002": f"{BACKEND}-{FILE_ROLE}-SYNTAX-002",
+    "ORCA-E003": f"{BACKEND}-{FILE_ROLE}-SYNTAX-003",
+    "ORCA-E004": f"{BACKEND}-{FILE_ROLE}-SYNTAX-004",
+    "ORCA-E005": f"{BACKEND}-{FILE_ROLE}-VALIDATION-001",
+    "ORCA-E006": f"{BACKEND}-{FILE_ROLE}-VALIDATION-002",
+    "ORCA-E007": f"{BACKEND}-{FILE_ROLE}-VALIDATION-003",
+    "ORCA-E020": f"{BACKEND}-{FILE_ROLE}-SYNTAX-020",
+    "ORCA-E021": f"{BACKEND}-{FILE_ROLE}-VALIDATION-020",
+    "ORCA-E022": f"{BACKEND}-{FILE_ROLE}-SYNTAX-021",
+    "ORCA-E023": f"{BACKEND}-{FILE_ROLE}-SYNTAX-022",
+    "ORCA-E027": f"{BACKEND}-{FILE_ROLE}-SYNTAX-023",
+    "ORCA-E028": f"{BACKEND}-{FILE_ROLE}-SYNTAX-024",
+    "ORCA-W001": f"{BACKEND}-{FILE_ROLE}-CONFIG-001",
+    "ORCA-W002": f"{BACKEND}-{FILE_ROLE}-SYNTAX-050",
+    "ORCA-W003": f"{BACKEND}-{FILE_ROLE}-SYNTAX-051",
+    "ORCA-W004": f"{BACKEND}-{FILE_ROLE}-CONFIG-002",
+    "ORCA-W005": f"{BACKEND}-{FILE_ROLE}-CONFIG-003",
+    "ORCA-W020": f"{BACKEND}-{FILE_ROLE}-CONFIG-020",
+    "ORCA-W021": f"{BACKEND}-{FILE_ROLE}-CONFIG-021",
+    # Typecheck rules
+    "TC-E001": f"{BACKEND}-{FILE_ROLE}-TYPE-001",
+    "TC-E002": f"{BACKEND}-{FILE_ROLE}-TYPE-002",
+    "TC-E003": f"{BACKEND}-{FILE_ROLE}-TYPE-003",
+    "TC-W001": f"{BACKEND}-{FILE_ROLE}-SCHEMA-001",
+    "TC-W002": f"{BACKEND}-{FILE_ROLE}-SCHEMA-002",
+    "TC-W003": f"{BACKEND}-{FILE_ROLE}-TYPE-004",
+}
+
+# ── Wiki page metadata ───────────────────────────────────────────────────────
+WIKI_METADATA: dict[str, dict[str, Any]] = {
+    "wiki/entities/ORCA_Quantum_Chemistry.md": {
+        "symbol": "ORCA_Quantum_Chemistry",
+        "sourceHints": ["ORCA quantum chemistry", "ORCA LSP", "orca-lsp"],
+    },
+    "wiki/entities/Language_Server_Protocol.md": {
+        "symbol": "Language_Server_Protocol",
+        "sourceHints": ["Language Server Protocol", "LSP", "language server"],
+    },
+    "wiki/entities/Diagnostic_Engine_v1.md": {
+        "symbol": "Diagnostic_Engine_v1",
+        "sourceHints": [
+            "diagnostic",
+            "Diagnostic Engine",
+            "rich_diagnostics",
+            "diagnostic_to_dict",
+        ],
+    },
+    "wiki/entities/OpenQC_Alignment.md": {
+        "symbol": "OpenQC_Alignment",
+        "sourceHints": ["OpenQC", "alignment"],
+    },
+    "wiki/entities/DFT_Functionals.md": {
+        "symbol": "DFT_Functionals",
+        "sourceHints": ["DFT", "functional", "density functional", "DFT_FUNCTIONALS"],
+    },
+    "wiki/entities/Basis_Sets.md": {
+        "symbol": "Basis_Sets",
+        "sourceHints": ["basis set", "BASIS_SETS"],
+    },
+    "wiki/entities/Job_Types.md": {
+        "symbol": "Job_Types",
+        "sourceHints": ["job type", "JOB_TYPES"],
+    },
+    "wiki/entities/Percent_Blocks.md": {
+        "symbol": "Percent_Blocks",
+        "sourceHints": ["block", "PERCENT_BLOCKS", "% block"],
+    },
+    "wiki/entities/Wavefunction_Methods.md": {
+        "symbol": "Wavefunction_Methods",
+        "sourceHints": ["wavefunction", "WAVEFUNCTION_METHODS", "MP2", "CCSD"],
+    },
+    "wiki/entities/Element_Symbols.md": {
+        "symbol": "Element_Symbols",
+        "sourceHints": ["element", "ELEMENTS", "atom symbol"],
+    },
+    "wiki/entities/Geometry_Section.md": {
+        "symbol": "Geometry_Section",
+        "sourceHints": ["geometry", "coordinate", "xyz", "atom"],
+    },
+    "wiki/entities/ORCA_Official_Documentation.md": {
+        "symbol": "ORCA_Official_Documentation",
+        "sourceHints": ["ORCA manual", "documentation", "official"],
+    },
+    "wiki/entities/ORCA_GitHub_Tools.md": {
+        "symbol": "ORCA_GitHub_Tools",
+        "sourceHints": ["GitHub", "tools", "CI"],
+    },
+    "wiki/entities/Auxiliary_Basis_Sets.md": {
+        "symbol": "Auxiliary_Basis_Sets",
+        "sourceHints": ["auxiliary", "RI", "fitting", "def2/J"],
+    },
+    "wiki/concepts/Density_Functional_Theory.md": {
+        "symbol": "Density_Functional_Theory",
+        "sourceHints": ["DFT", "density functional theory", "functionals"],
+    },
+    "wiki/concepts/Basis_Set_Selection.md": {
+        "symbol": "Basis_Set_Selection",
+        "sourceHints": ["basis selection", "basis set choice"],
+    },
+    "wiki/concepts/Coupled_Cluster_Theory.md": {
+        "symbol": "Coupled_Cluster_Theory",
+        "sourceHints": ["coupled cluster", "CCSD", "DLPNO"],
+    },
+    "wiki/concepts/Dispersion_Corrections.md": {
+        "symbol": "Dispersion_Corrections",
+        "sourceHints": ["dispersion", "D3", "D4", "D3BJ"],
+    },
+    "wiki/concepts/DLPNO_Methods.md": {
+        "symbol": "DLPNO_Methods",
+        "sourceHints": ["DLPNO", "local pair", "domain-based"],
+    },
+    "wiki/concepts/Frequency_Calculation.md": {
+        "symbol": "Frequency_Calculation",
+        "sourceHints": ["frequency", "FREQ", "vibrational"],
+    },
+    "wiki/concepts/Geometry_Optimization.md": {
+        "symbol": "Geometry_Optimization",
+        "sourceHints": ["optimization", "OPT", "geometry opt"],
+    },
+    "wiki/concepts/Compound_Jobs.md": {
+        "symbol": "Compound_Jobs",
+        "sourceHints": ["compound", "job type", "OPT FREQ"],
+    },
+    "wiki/concepts/Solvation_Models.md": {
+        "symbol": "Solvation_Models",
+        "sourceHints": ["solvation", "CPCM", "SMD"],
+    },
+    "wiki/concepts/Time_Dependent_DFT.md": {
+        "symbol": "Time_Dependent_DFT",
+        "sourceHints": ["TDDFT", "time-dependent", "excited state"],
+    },
+    "wiki/concepts/Transition_State_Search.md": {
+        "symbol": "Transition_State_Search",
+        "sourceHints": ["transition state", "TS", "saddle point"],
+    },
+    "wiki/synthesis/Input_File_Guide.md": {
+        "symbol": "Input_File_Guide",
+        "sourceHints": ["input file", "inp file", "file format"],
+    },
+    "wiki/synthesis/ORCA_LSP_API_Reference.md": {
+        "symbol": "ORCA_LSP_API_Reference",
+        "sourceHints": ["API", "agent", "tool", "CLI"],
+    },
+    "wiki/synthesis/ORCA_Output_Guide.md": {
+        "symbol": "ORCA_Output_Guide",
+        "sourceHints": ["output", "log", "out file", "parse-log"],
+    },
+    "wiki/synthesis/Diagnostics_Catalog.md": {
+        "symbol": "Diagnostics_Catalog",
+        "sourceHints": ["diagnostics", "rule", "code", "catalog"],
+    },
+}
+
+# Map from wiki path (without wiki/ prefix) to raw asset path
+WIKI_TO_RAW: dict[str, str] = {
+    "entities/Diagnostic_Engine_v1.md": "raw/assets/docs/DIAGNOSTIC_ENGINE_V1.md",
+    "entities/OpenQC_Alignment.md": "raw/assets/docs/OPENQC_ALIGNMENT.md",
+    "entities/ORCA_Official_Documentation.md": "raw/assets/orca-input-format.md",
+    "entities/ORCA_Quantum_Chemistry.md": "raw/assets/README.md",
+    "entities/Language_Server_Protocol.md": "raw/assets/docs/ARCHITECTURE.md",
+    "synthesis/Input_File_Guide.md": "raw/assets/orca-input-format.md",
+    "synthesis/ORCA_Output_Guide.md": "raw/assets/orca-output-format.md",
+    "synthesis/ORCA_LSP_API_Reference.md": "raw/assets/docs/ARCHITECTURE.md",
+    "synthesis/Diagnostics_Catalog.md": "raw/assets/docs/DIAGNOSTIC_ENGINE_V1.md",
+    "concepts/Basis_Set_Selection.md": "raw/assets/orca-basis-sets-reference.md",
+    "concepts/Coupled_Cluster_Theory.md": "raw/assets/orca-keywords-reference.md",
+    "concepts/Density_Functional_Theory.md": "raw/assets/orca-keywords-reference.md",
+    "concepts/Dispersion_Corrections.md": "raw/assets/orca-keywords-reference.md",
+    "concepts/DLPNO_Methods.md": "raw/assets/orca-keywords-reference.md",
+    "concepts/Frequency_Calculation.md": "raw/assets/orca-compound-jobs.md",
+    "concepts/Geometry_Optimization.md": "raw/assets/orca-compound-jobs.md",
+    "concepts/Compound_Jobs.md": "raw/assets/orca-compound-jobs.md",
+    "concepts/Solvation_Models.md": "raw/assets/orca-tutorials.md",
+    "concepts/Time_Dependent_DFT.md": "raw/assets/orca-tutorials.md",
+    "concepts/Transition_State_Search.md": "raw/assets/orca-tutorials.md",
+    "entities/DFT_Functionals.md": "raw/assets/orca-keywords-reference.md",
+    "entities/Basis_Sets.md": "raw/assets/orca-basis-sets-reference.md",
+    "entities/Job_Types.md": "raw/assets/orca-compound-jobs.md",
+    "entities/Percent_Blocks.md": "raw/assets/orca-keywords-reference.md",
+    "entities/Wavefunction_Methods.md": "raw/assets/orca-keywords-reference.md",
+    "entities/Element_Symbols.md": "raw/assets/orca-keywords-reference.md",
+    "entities/Geometry_Section.md": "raw/assets/orca-input-format.md",
+    "entities/Auxiliary_Basis_Sets.md": "raw/assets/orca-basis-sets-reference.md",
+    "entities/ORCA_GitHub_Tools.md": "raw/assets/orca-github-tools.md",
+}
+
+
+def find_project_root() -> Path:
+    """Find the project root by looking for pyproject.toml."""
+    candidate = Path(__file__).resolve().parent.parent
+    if (candidate / "pyproject.toml").exists():
+        return candidate
+    cwd = Path.cwd()
+    if (cwd / "pyproject.toml").exists():
+        return cwd
+    return candidate
+
+
+def _rel(root: Path, path: Path) -> str:
+    """Return repo-relative path string."""
+    return str(path.relative_to(root))
+
+
+def discover_source_files(root: Path) -> list[Path]:
+    """Discover Python source files under src/orca_lsp."""
+    src_dir = root / "src" / "orca_lsp"
+    if not src_dir.is_dir():
+        return []
+    return sorted(src_dir.rglob("*.py"))
+
+
+def discover_wiki_pages(root: Path) -> list[Path]:
+    """Discover wiki markdown files under wiki/."""
+    wiki_dir = root / "wiki"
+    if not wiki_dir.is_dir():
+        return []
+    return sorted(wiki_dir.rglob("*.md"))
+
+
+def discover_raw_assets(root: Path) -> list[Path]:
+    """Discover raw asset files under raw/."""
+    raw_dir = root / "raw"
+    if not raw_dir.is_dir():
+        return []
+    assets = []
+    for f in sorted(raw_dir.rglob("*")):
+        if f.is_file() and f.suffix in {".md", ".inp", ".json"}:
+            assets.append(f)
+    return assets
+
+
+def write_raw_asset_manifest(root: Path) -> Path:
+    """Write a deterministic manifest for all raw evidence assets."""
+    manifest_path = root / "raw" / "assets" / "manifest.json"
+    entries = []
+    for raw_path in discover_raw_assets(root):
+        if raw_path == manifest_path:
+            continue
+        raw_rel = _rel(root, raw_path)
+        entries.append(
+            {
+                "path": raw_rel.removeprefix("raw/assets/"),
+                "source_type": "raw_asset",
+                "source_url": f"{REPOSITORY}/blob/main/{raw_rel}",
+                "stable_id": raw_rel.replace("/", "-").replace(".", "-"),
+            }
+        )
+    payload = {
+        "manifest_version": "1.0.0",
+        "schema_version": "provenance-manifest-v1",
+        "repository": "newtontech/orca-lsp",
+        "entries": entries,
+    }
+    manifest_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def extract_docstrings(source_path: Path) -> list[dict[str, str]]:
+    """Extract module-level and top-level docstrings from a Python source file."""
+    text = source_path.read_text(encoding="utf-8", errors="replace")
+    results: list[dict[str, str]] = []
+
+    # Module docstring (first triple-quoted string)
+    mod_match = re.match(r'(?:"""|\'\'\')(.*?)(?:"""|\'\'\')', text, re.DOTALL)
+    if mod_match:
+        results.append(
+            {
+                "symbol": source_path.stem,
+                "docstring": mod_match.group(1).strip(),
+                "line": 1,
+            }
+        )
+
+    # Class/function docstrings
+    for match in re.finditer(
+        r'(?:class|def|async def)\s+(\w+)[^"]*(?:"""|\'\'\')(.*?)(?:"""|\'\'\')',
+        text,
+        re.DOTALL,
+    ):
+        results.append(
+            {
+                "symbol": match.group(1),
+                "docstring": match.group(2).strip(),
+                "line": text[: match.start()].count("\n") + 1,
+            }
+        )
+        if len(results) >= 10:
+            break
+
+    return results
+
+
+def match_docstring_to_wiki(
+    docstring_entries: list[dict[str, str]],
+) -> list[dict[str, str]]:
+    """Match docstring entries to wiki pages based on content hints."""
+    matched: list[dict[str, str]] = []
+    for entry in docstring_entries:
+        doc_text = entry["docstring"].lower()
+        best_match: str | None = None
+        best_score = 0
+        for wiki_path, meta in WIKI_METADATA.items():
+            for hint in meta["sourceHints"]:
+                if hint.lower() in doc_text:
+                    score = len(hint)
+                    if score > best_score:
+                        best_score = score
+                        best_match = wiki_path
+        if best_match:
+            matched.append(
+                {
+                    "path": entry["_sourceRel"],
+                    "wikiPath": best_match,
+                    "symbol": WIKI_METADATA[best_match]["symbol"],
+                }
+            )
+    return matched
+
+
+def build_docstrings(root: Path) -> list[dict[str, str]]:
+    """Build the docstrings[] array mapping source files → wiki pages."""
+    results: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for source_path in discover_source_files(root):
+        source_rel = _rel(root, source_path)
+        entries = extract_docstrings(source_path)
+        for e in entries:
+            e["_sourceRel"] = source_rel
+        matched = match_docstring_to_wiki(entries)
+        for m in matched:
+            key = (m["path"], m["wikiPath"])
+            if key not in seen:
+                seen.add(key)
+                results.append(m)
+    return results
+
+
+def build_wiki_sources(root: Path) -> list[dict[str, str]]:
+    """Build the wikiSources[] array mapping wiki pages → raw assets."""
+    results: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for wiki_path in discover_wiki_pages(root):
+        wiki_rel = _rel(root, wiki_path)
+        wiki_short = wiki_rel.removeprefix("wiki/")
+        raw_rel = WIKI_TO_RAW.get(wiki_short)
+        if raw_rel and raw_rel not in seen:
+            seen.add(raw_rel)
+            results.append(
+                {
+                    "wikiPath": wiki_rel,
+                    "rawPath": raw_rel,
+                    "sourceUrl": f"{REPOSITORY}/blob/main/{raw_rel}",
+                }
+            )
+    return sorted(results, key=lambda x: x["wikiPath"])
+
+
+def _extract_legacy_codes(path: Path, root: Path) -> list[str]:
+    """Extract rule code strings matching <PREFIX>-<type><digits> from a file."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    # Match codes like ORCA-E001, TC-W001, TC-E003 etc.
+    pattern = re.compile(r"\b([A-Z]{2,6})-[EW](\d{3,4})\b")
+    codes: list[str] = []
+    for match in pattern.finditer(text):
+        code = match.group(0)
+        # Verify it looks like a real diagnostic code
+        if re.match(r"^[A-Z]{2,6}-[EW]\d{3,4}$", code):
+            codes.append(code)
+    return codes
+
+
+def build_rule_ids(root: Path) -> list[dict[str, str]]:
+    """Build the ruleIds[] array with OpenQC format codes.
+
+    Rule codes follow <BACKEND>-<FILE_ROLE>-<CATEGORY>-NNN.
+    We map existing legacy codes (ORCA-E001, TC-W001) to the new format.
+    """
+    lint_path = root / "src" / "orca_lsp" / "features" / "lint.py"
+    typecheck_path = root / "src" / "orca_lsp" / "features" / "typecheck.py"
+
+    legacy_codes: set[str] = set()
+    if lint_path.exists():
+        legacy_codes.update(_extract_legacy_codes(lint_path, root))
+    if typecheck_path.exists():
+        legacy_codes.update(_extract_legacy_codes(typecheck_path, root))
+
+    rule_ids: list[dict[str, str]] = []
+    seen: set[str] = set()
+
+    for legacy_code in sorted(legacy_codes):
+        openqc_code = LEGACY_CODE_MAP.get(legacy_code)
+        if openqc_code and openqc_code not in seen:
+            seen.add(openqc_code)
+            # Determine which file this code originates from
+            source_path = "src/orca_lsp/features/lint.py"
+            if legacy_code.startswith("TC-"):
+                source_path = "src/orca_lsp/features/typecheck.py"
+            rule_ids.append(
+                {
+                    "code": openqc_code,
+                    "sourcePath": source_path,
+                }
+            )
+
+    return rule_ids
+
+
+def build_source_urls(root: Path) -> list[dict[str, str]]:
+    """Build the sourceUrls[] array mapping raw assets → GitHub URLs."""
+    results: list[dict[str, str]] = []
+    for raw_path in discover_raw_assets(root):
+        raw_rel = _rel(root, raw_path)
+        results.append(
+            {
+                "rawPath": raw_rel,
+                "url": f"{REPOSITORY}/blob/main/{raw_rel}",
+            }
+        )
+    return sorted(results, key=lambda x: x["rawPath"])
+
+
+def build_raw_manifest(root: Path) -> dict[str, Any]:
+    """Build the OpenQC rawManifest descriptor."""
+    manifest_path = root / "raw" / "assets" / "manifest.json"
+    return {
+        "path": _rel(root, manifest_path),
+        "ok": manifest_path.is_file() and manifest_path.stat().st_size > 0,
+    }
+
+
+def generate_report(root: Path | None = None) -> dict[str, Any]:
+    """Generate the full OpenQC v1 traceability report."""
+    if root is None:
+        root = find_project_root()
+
+    write_raw_asset_manifest(root)
+    docstrings = build_docstrings(root)
+    wiki_sources = build_wiki_sources(root)
+    rule_ids = build_rule_ids(root)
+    source_urls = build_source_urls(root)
+    raw_manifest = build_raw_manifest(root)
+    docstrings_linked = sum(
+        1 for item in docstrings if (root / item["path"]).exists() and (root / item["wikiPath"]).exists()
+    )
+    broken_wiki_links = sum(1 for item in docstrings if not (root / item["wikiPath"]).exists())
+    wiki_sources_without_raw = sum(1 for item in wiki_sources if not (root / item["rawPath"]).exists())
+
+    report: dict[str, Any] = {
+        "schemaVersion": SCHEMA_VERSION,
+        "serverId": SERVER_ID,
+        "repository": REPOSITORY,
+        "languageId": LANGUAGE_ID,
+        "generatedAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "summary": {
+            "docstringsTotal": len(docstrings),
+            "docstringsLinked": docstrings_linked,
+            "brokenWikiLinks": broken_wiki_links,
+            "wikiSourcesWithoutRaw": wiki_sources_without_raw,
+            "rawManifestFailures": 0 if raw_manifest["ok"] else 1,
+            "ruleIdsTotal": len(rule_ids),
+            "sourceUrlsTotal": len(source_urls),
+            "wikiSourcesTotal": len(wiki_sources),
+        },
+        "docstrings": docstrings,
+        "wikiSources": wiki_sources,
+        "ruleIds": rule_ids,
+        "sourceUrls": source_urls,
+        "rawManifest": raw_manifest,
+    }
+    return report
+
+
+def write_report(report: dict[str, Any], output_path: Path) -> None:
+    """Write the report as formatted JSON."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def validate_report(report: dict[str, Any]) -> list[str]:
+    """Validate the report against the OpenQC v1 schema contract.
+
+    Returns a list of error messages (empty = valid).
+    """
+    errors: list[str] = []
+
+    required_top = [
+        "schemaVersion",
+        "serverId",
+        "repository",
+        "languageId",
+        "generatedAt",
+        "summary",
+        "docstrings",
+        "wikiSources",
+        "ruleIds",
+        "sourceUrls",
+        "rawManifest",
+    ]
+    for field in required_top:
+        if field not in report:
+            errors.append(f"Missing top-level field: {field}")
+
+    if errors:
+        return errors
+
+    if report["schemaVersion"] != SCHEMA_VERSION:
+        errors.append(
+            f"schemaVersion must be {SCHEMA_VERSION!r}, " f"got {report['schemaVersion']!r}"
+        )
+    if report["serverId"] != SERVER_ID:
+        errors.append(f"serverId must be {SERVER_ID!r}, got {report['serverId']!r}")
+    if report["repository"] != REPOSITORY:
+        errors.append(f"repository must be {REPOSITORY!r}, got {report['repository']!r}")
+    if report["languageId"] != LANGUAGE_ID:
+        errors.append(f"languageId must be {LANGUAGE_ID!r}, got {report['languageId']!r}")
+    if not report.get("generatedAt"):
+        errors.append("generatedAt must be non-empty")
+
+    # docstrings
+    docstrings = report.get("docstrings", [])
+    if not docstrings:
+        errors.append("docstrings[] must be non-empty")
+    for i, ds in enumerate(docstrings):
+        if not ds.get("path"):
+            errors.append(f"docstrings[{i}].path must be non-empty")
+        if not ds.get("wikiPath"):
+            errors.append(f"docstrings[{i}].wikiPath must be non-empty")
+        if not ds.get("symbol"):
+            errors.append(f"docstrings[{i}].symbol must be non-empty")
+
+    # wikiSources
+    wiki_sources = report.get("wikiSources", [])
+    if not wiki_sources:
+        errors.append("wikiSources[] must be non-empty")
+    for i, ws in enumerate(wiki_sources):
+        if not ws.get("wikiPath"):
+            errors.append(f"wikiSources[{i}].wikiPath must be non-empty")
+        if not ws.get("rawPath"):
+            errors.append(f"wikiSources[{i}].rawPath must be non-empty")
+        if not ws.get("sourceUrl"):
+            errors.append(f"wikiSources[{i}].sourceUrl must be non-empty")
+
+    # ruleIds
+    rule_ids = report.get("ruleIds", [])
+    if not rule_ids:
+        errors.append("ruleIds[] must be non-empty")
+    code_pattern = re.compile(r"^[A-Z]+-[A-Z]+-[A-Z]+-\d+$")
+    for i, ri in enumerate(rule_ids):
+        code = ri.get("code", "")
+        if not re.match(code_pattern, code):
+            errors.append(
+                f"ruleIds[{i}].code {code!r} does not match "
+                f"<BACKEND>-<FILE_ROLE>-<CATEGORY>-NNN"
+            )
+        if not ri.get("sourcePath"):
+            errors.append(f"ruleIds[{i}].sourcePath must be non-empty")
+
+    # sourceUrls
+    source_urls = report.get("sourceUrls", [])
+    if not source_urls:
+        errors.append("sourceUrls[] must be non-empty")
+    for i, su in enumerate(source_urls):
+        if not su.get("rawPath"):
+            errors.append(f"sourceUrls[{i}].rawPath must be non-empty")
+        if not su.get("url"):
+            errors.append(f"sourceUrls[{i}].url must be non-empty")
+
+    # summary
+    summary = report.get("summary", {})
+    for field in [
+        "docstringsTotal",
+        "docstringsLinked",
+        "brokenWikiLinks",
+        "wikiSourcesWithoutRaw",
+        "rawManifestFailures",
+    ]:
+        if not isinstance(summary.get(field), int) or summary[field] < 0:
+            errors.append(f"summary.{field} must be a non-negative integer")
+
+    # rawManifest
+    raw_manifest = report.get("rawManifest", {})
+    if not isinstance(raw_manifest, dict) or not raw_manifest:
+        errors.append("rawManifest must be a non-empty object")
+    else:
+        manifest_path = raw_manifest.get("path")
+        if not isinstance(manifest_path, str) or not manifest_path:
+            errors.append("rawManifest.path must be non-empty")
+        elif manifest_path.startswith("/") or ".." in Path(manifest_path).parts:
+            errors.append("rawManifest.path must be repository-relative")
+        if not isinstance(raw_manifest.get("ok"), bool):
+            errors.append("rawManifest.ok must be boolean")
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate OpenQC v1 traceability report")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("reports") / "docstring-wiki-raw-traceability.json",
+        help="Output path for the report JSON",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="Project root directory (auto-detected by default)",
+    )
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Validate an existing report instead of generating one",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Generate report and validate it, exit non-zero on validation failure",
+    )
+    args = parser.parse_args(argv)
+
+    root = args.root if args.root else find_project_root()
+
+    if args.validate:
+        if not args.output.exists():
+            print(f"Report not found: {args.output}", file=sys.stderr)
+            return 1
+        report = json.loads(args.output.read_text(encoding="utf-8"))
+        errors = validate_report(report)
+        if errors:
+            for err in errors:
+                print(f"VALIDATION ERROR: {err}", file=sys.stderr)
+            return 1
+        print(f"Report is valid: {args.output}")
+        return 0
+
+    report = generate_report(root)
+    write_report(report, args.output)
+    print(f"Report written: {args.output}")
+    print(f"  docstrings: {len(report['docstrings'])}")
+    print(f"  wikiSources: {len(report['wikiSources'])}")
+    print(f"  ruleIds: {len(report['ruleIds'])}")
+    print(f"  sourceUrls: {len(report['sourceUrls'])}")
+    print(f"  rawManifest: {report['rawManifest']['path']} ok={report['rawManifest']['ok']}")
+
+    if args.check:
+        errors = validate_report(report)
+        if errors:
+            for err in errors:
+                print(f"VALIDATION ERROR: {err}", file=sys.stderr)
+            return 1
+        print("Validation: PASSED")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_traceability_report.py
+++ b/tests/test_traceability_report.py
@@ -1,0 +1,428 @@
+"""Tests for the OpenQC v1 docstring/wiki/raw traceability report."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add the scripts directory to path so we can import the module
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from generate_traceability_report import (  # type: ignore[import]  # noqa: E402
+    SCHEMA_VERSION,
+    SERVER_ID,
+    REPOSITORY,
+    LANGUAGE_ID,
+    LEGACY_CODE_MAP,
+    WIKI_METADATA,
+    WIKI_TO_RAW,
+    build_docstrings,
+    build_wiki_sources,
+    build_rule_ids,
+    build_source_urls,
+    build_raw_manifest,
+    generate_report,
+    validate_report,
+    write_report,
+    find_project_root,
+)
+
+
+@pytest.fixture(scope="module")
+def project_root() -> Path:
+    """Return the project root directory."""
+    return find_project_root()
+
+
+@pytest.fixture(scope="module")
+def report(project_root: Path) -> dict:
+    """Generate the full report once for all tests."""
+    return generate_report(project_root)
+
+
+class TestReportSchema:
+    """Tests for the top-level report schema and field requirements."""
+
+    def test_schema_version(self, report):
+        assert report["schemaVersion"] == SCHEMA_VERSION
+
+    def test_server_id(self, report):
+        assert report["serverId"] == SERVER_ID
+
+    def test_repository(self, report):
+        assert report["repository"] == REPOSITORY
+
+    def test_language_id(self, report):
+        assert report["languageId"] == LANGUAGE_ID
+
+    def test_generated_at_non_empty(self, report):
+        assert report["generatedAt"]
+        assert "T" in report["generatedAt"]
+        assert report["generatedAt"].endswith("Z")
+
+    def test_summary_has_counts(self, report):
+        summary = report["summary"]
+        assert "docstringsTotal" in summary
+        assert "docstringsLinked" in summary
+        assert "brokenWikiLinks" in summary
+        assert "wikiSourcesWithoutRaw" in summary
+        assert "rawManifestFailures" in summary
+
+    def test_summary_counts_match_arrays(self, report):
+        s = report["summary"]
+        assert s["docstringsTotal"] == len(report["docstrings"])
+        assert s["docstringsLinked"] == len(report["docstrings"])
+        assert s["brokenWikiLinks"] == 0
+        assert s["wikiSourcesWithoutRaw"] == 0
+        assert s["rawManifestFailures"] == 0
+
+
+class TestDocstrings:
+    """Tests for the docstrings[] array."""
+
+    def test_docstrings_non_empty(self, report):
+        assert len(report["docstrings"]) > 0
+
+    def test_docstrings_have_required_fields(self, report):
+        for i, ds in enumerate(report["docstrings"]):
+            assert ds.get("path"), f"docstrings[{i}].path is empty"
+            assert ds.get("wikiPath"), f"docstrings[{i}].wikiPath is empty"
+            assert ds.get("symbol"), f"docstrings[{i}].symbol is empty"
+
+    def test_docstrings_paths_are_repo_relative(self, report):
+        for ds in report["docstrings"]:
+            assert ds["path"].startswith(
+                "src/"
+            ), f"path should be repo-relative, got {ds['path']!r}"
+
+    def test_docstrings_wiki_paths_start_with_wiki(self, report):
+        for ds in report["docstrings"]:
+            assert ds["wikiPath"].startswith(
+                "wiki/"
+            ), f"wikiPath should start with wiki/, got {ds['wikiPath']!r}"
+
+    def test_docstrings_wiki_paths_exist(self, report, project_root):
+        for ds in report["docstrings"]:
+            wiki_full = project_root / ds["wikiPath"]
+            assert wiki_full.exists(), f"Wiki page not found: {wiki_full}"
+
+    def test_docstrings_source_paths_exist(self, report, project_root):
+        for ds in report["docstrings"]:
+            src_full = project_root / ds["path"]
+            assert src_full.exists(), f"Source file not found: {src_full}"
+
+    def test_docstrings_no_duplicates(self, report):
+        seen: set[tuple[str, str]] = set()
+        for ds in report["docstrings"]:
+            key = (ds["path"], ds["wikiPath"])
+            assert key not in seen, f"Duplicate docstring entry: {key}"
+            seen.add(key)
+
+
+class TestWikiSources:
+    """Tests for the wikiSources[] array."""
+
+    def test_wiki_sources_non_empty(self, report):
+        assert len(report["wikiSources"]) > 0
+
+    def test_wiki_sources_have_required_fields(self, report):
+        for i, ws in enumerate(report["wikiSources"]):
+            assert ws.get("wikiPath"), f"wikiSources[{i}].wikiPath is empty"
+            assert ws.get("rawPath"), f"wikiSources[{i}].rawPath is empty"
+            assert ws.get("sourceUrl"), f"wikiSources[{i}].sourceUrl is empty"
+
+    def test_wiki_sources_wiki_paths_start_with_wiki(self, report):
+        for ws in report["wikiSources"]:
+            assert ws["wikiPath"].startswith(
+                "wiki/"
+            ), f"wikiPath should start with wiki/, got {ws['wikiPath']!r}"
+
+    def test_wiki_sources_raw_paths_start_with_raw(self, report):
+        for ws in report["wikiSources"]:
+            assert ws["rawPath"].startswith(
+                "raw/"
+            ), f"rawPath should start with raw/, got {ws['rawPath']!r}"
+
+    def test_wiki_sources_wiki_paths_exist(self, report, project_root):
+        for ws in report["wikiSources"]:
+            wiki_full = project_root / ws["wikiPath"]
+            assert wiki_full.exists(), f"Wiki page not found: {wiki_full}"
+
+    def test_wiki_sources_raw_paths_exist(self, report, project_root):
+        for ws in report["wikiSources"]:
+            raw_full = project_root / ws["rawPath"]
+            assert raw_full.exists(), f"Raw asset not found: {raw_full}"
+
+    def test_wiki_sources_urls_are_valid_github(self, report):
+        for ws in report["wikiSources"]:
+            assert ws["sourceUrl"].startswith(
+                REPOSITORY
+            ), f"sourceUrl should start with {REPOSITORY}, got {ws['sourceUrl']!r}"
+            assert "/blob/main/" in ws["sourceUrl"]
+
+    def test_wiki_sources_no_duplicates(self, report):
+        seen: set[str] = set()
+        for ws in report["wikiSources"]:
+            assert ws["rawPath"] not in seen, f"Duplicate wiki source entry: {ws['rawPath']}"
+            seen.add(ws["rawPath"])
+
+
+class TestRuleIds:
+    """Tests for the ruleIds[] array."""
+
+    CODE_PATTERN = r"^[A-Z]+-[A-Z]+-[A-Z]+-\d+$"
+
+    def test_rule_ids_non_empty(self, report):
+        assert len(report["ruleIds"]) > 0
+
+    def test_rule_ids_have_required_fields(self, report):
+        for i, ri in enumerate(report["ruleIds"]):
+            assert ri.get("code"), f"ruleIds[{i}].code is empty"
+            assert ri.get("sourcePath"), f"ruleIds[{i}].sourcePath is empty"
+
+    def test_rule_ids_code_format(self, report):
+        for i, ri in enumerate(report["ruleIds"]):
+            code = ri["code"]
+            assert (
+                len(code.split("-")) >= 4
+            ), f"ruleIds[{i}].code {code!r} should have at least 4 parts"
+            assert ri.get("sourcePath", "").startswith("src/"), (
+                f"ruleIds[{i}].sourcePath should be repo-relative, "
+                f"got {ri.get('sourcePath', '')!r}"
+            )
+
+    def test_rule_ids_no_duplicates(self, report):
+        seen: set[str] = set()
+        for ri in report["ruleIds"]:
+            assert ri["code"] not in seen, f"Duplicate rule ID code: {ri['code']}"
+            seen.add(ri["code"])
+
+    def test_rule_ids_count_matches_legacy_map(self, report):
+        # All legacy codes should be mapped
+        mapped = set(LEGACY_CODE_MAP.values())
+        reported = {ri["code"] for ri in report["ruleIds"]}
+        assert reported == mapped, (
+            f"Reported codes differ from LEGACY_CODE_MAP\n"
+            f"Missing: {mapped - reported}\n"
+            f"Extra: {reported - mapped}"
+        )
+
+    def test_rule_ids_source_paths_exist(self, report, project_root):
+        for ri in report["ruleIds"]:
+            src_full = project_root / ri["sourcePath"]
+            assert src_full.exists(), f"Source file not found: {src_full}"
+
+
+class TestSourceUrls:
+    """Tests for the sourceUrls[] array."""
+
+    def test_source_urls_non_empty(self, report):
+        assert len(report["sourceUrls"]) > 0
+
+    def test_source_urls_have_required_fields(self, report):
+        for i, su in enumerate(report["sourceUrls"]):
+            assert su.get("rawPath"), f"sourceUrls[{i}].rawPath is empty"
+            assert su.get("url"), f"sourceUrls[{i}].url is empty"
+
+    def test_source_urls_raw_paths_start_with_raw(self, report):
+        for su in report["sourceUrls"]:
+            assert su["rawPath"].startswith(
+                "raw/"
+            ), f"rawPath should start with raw/, got {su['rawPath']!r}"
+
+    def test_source_urls_raw_paths_exist(self, report, project_root):
+        for su in report["sourceUrls"]:
+            raw_full = project_root / su["rawPath"]
+            assert raw_full.exists(), f"Raw asset not found: {raw_full}"
+
+    def test_source_urls_are_valid_github(self, report):
+        for su in report["sourceUrls"]:
+            assert su["url"].startswith(REPOSITORY)
+            assert "/blob/main/" in su["url"]
+
+    def test_source_urls_no_duplicates(self, report):
+        seen: set[str] = set()
+        for su in report["sourceUrls"]:
+            assert su["rawPath"] not in seen, f"Duplicate source URL entry: {su['rawPath']}"
+            seen.add(su["rawPath"])
+
+
+class TestRawManifest:
+    """Tests for the rawManifest object."""
+
+    def test_raw_manifest_non_empty(self, report):
+        assert len(report["rawManifest"]) > 0
+
+    def test_raw_manifest_path_is_repo_relative(self, report):
+        manifest_path = report["rawManifest"]["path"]
+        assert manifest_path.startswith(
+            "raw/assets/"
+        ), f"rawManifest.path should start with raw/assets/, got {manifest_path!r}"
+
+    def test_raw_manifest_ok_is_boolean(self, report):
+        ok_val = report["rawManifest"]["ok"]
+        assert isinstance(ok_val, bool), f"rawManifest.ok should be bool, got {type(ok_val).__name__}"
+
+    def test_raw_manifest_paths_exist(self, report, project_root):
+        full_path = project_root / report["rawManifest"]["path"]
+        assert full_path.exists(), f"Raw manifest not found: {full_path}"
+
+    def test_raw_manifest_all_ok(self, report):
+        assert report["rawManifest"]["ok"] is True
+
+    def test_raw_manifest_consistent_with_source_urls(self, report):
+        manifest_paths = {report["rawManifest"]["path"]}
+        source_url_paths = {su["rawPath"] for su in report["sourceUrls"]}
+        assert manifest_paths <= source_url_paths
+
+
+class TestBuilderFunctions:
+    """Tests for individual builder functions."""
+
+    def test_build_docstrings_returns_list_of_dicts(self, project_root):
+        result = build_docstrings(project_root)
+        assert isinstance(result, list)
+        if result:
+            assert isinstance(result[0], dict)
+
+    def test_build_wiki_sources_returns_list_of_dicts(self, project_root):
+        result = build_wiki_sources(project_root)
+        assert isinstance(result, list)
+        if result:
+            assert isinstance(result[0], dict)
+
+    def test_build_rule_ids_returns_list_of_dicts(self, project_root):
+        result = build_rule_ids(project_root)
+        assert isinstance(result, list)
+        if result:
+            assert isinstance(result[0], dict)
+
+    def test_build_source_urls_returns_list_of_dicts(self, project_root):
+        result = build_source_urls(project_root)
+        assert isinstance(result, list)
+        if result:
+            assert isinstance(result[0], dict)
+
+    def test_build_raw_manifest_returns_dict(self, project_root):
+        result = build_raw_manifest(project_root)
+        assert isinstance(result, dict)
+
+
+class TestValidation:
+    """Tests for the report validation function."""
+
+    def test_valid_report_passes(self, report):
+        errors = validate_report(report)
+        assert errors == [], f"Validation errors: {errors}"
+
+    def test_validation_fails_missing_field(self):
+        report = {}
+        errors = validate_report(report)
+        assert len(errors) > 0
+        assert any("schemaVersion" in e for e in errors)
+
+    def test_validation_fails_wrong_schema_version(self, report):
+        bad_report = dict(report)
+        bad_report["schemaVersion"] = "wrong"
+        errors = validate_report(bad_report)
+        assert any("schemaVersion" in e for e in errors)
+
+    def test_validation_fails_empty_docstrings(self, report):
+        bad_report = dict(report)
+        bad_report["docstrings"] = []
+        errors = validate_report(bad_report)
+        assert any("non-empty" in e.lower() for e in errors)
+
+    def test_validation_fails_empty_wiki_sources(self, report):
+        bad_report = dict(report)
+        bad_report["wikiSources"] = []
+        errors = validate_report(bad_report)
+        assert any("non-empty" in e.lower() for e in errors)
+
+    def test_validation_fails_empty_rule_ids(self, report):
+        bad_report = dict(report)
+        bad_report["ruleIds"] = []
+        errors = validate_report(bad_report)
+        assert any("non-empty" in e.lower() for e in errors)
+
+    def test_validation_fails_empty_source_urls(self, report):
+        bad_report = dict(report)
+        bad_report["sourceUrls"] = []
+        errors = validate_report(bad_report)
+        assert any("non-empty" in e.lower() for e in errors)
+
+    def test_validation_fails_empty_raw_manifest(self, report):
+        bad_report = dict(report)
+        bad_report["rawManifest"] = {}
+        errors = validate_report(bad_report)
+        assert any("non-empty" in e.lower() for e in errors)
+
+    def test_validation_fails_docstring_missing_path(self, report):
+        bad_report = dict(report)
+        bad_report["docstrings"] = [{"wikiPath": "x", "symbol": "y"}]
+        errors = validate_report(bad_report)
+        assert any("path" in e.lower() for e in errors)
+
+    def test_validation_fails_rule_id_bad_format(self, report):
+        bad_report = dict(report)
+        bad_report["ruleIds"] = [{"code": "BAD", "sourcePath": "x.py"}]
+        errors = validate_report(bad_report)
+        assert any("pattern" in e.lower() or "match" in e.lower() for e in errors)
+
+    def test_validation_fails_raw_manifest_non_bool(self, report):
+        bad_report = dict(report)
+        bad_report["rawManifest"] = {"path": "raw/assets/manifest.json", "ok": "not_bool"}
+        errors = validate_report(bad_report)
+        assert any("boolean" in e.lower() for e in errors)
+
+
+class TestWriteAndReread:
+    """Tests for report serialization/deserialization round-trip."""
+
+    def test_write_and_validate(self, report, project_root, tmp_path):
+        output = tmp_path / "test-report.json"
+        write_report(report, output)
+        assert output.exists()
+        reread = json.loads(output.read_text(encoding="utf-8"))
+        errors = validate_report(reread)
+        assert errors == [], f"Validation errors after round-trip: {errors}"
+
+    def test_write_generated_report(self, project_root, tmp_path):
+        """Test that generating and writing from scratch works."""
+        output = tmp_path / "fresh-report.json"
+        fresh = generate_report(project_root)
+        write_report(fresh, output)
+        assert output.exists()
+        content = json.loads(output.read_text(encoding="utf-8"))
+        assert content["schemaVersion"] == SCHEMA_VERSION
+
+
+class TestWIKIMetadata:
+    """Tests for the wiki metadata integrity."""
+
+    def test_all_wiki_metadata_paths_exist(self, project_root):
+        for wiki_rel in WIKI_METADATA:
+            wiki_full = project_root / wiki_rel
+            assert wiki_full.exists(), f"Wiki metadata path not found: {wiki_full}"
+
+    def test_all_wiki_to_raw_exists(self, project_root):
+        for raw_rel in WIKI_TO_RAW.values():
+            raw_full = project_root / raw_rel
+            assert raw_full.exists(), f"Wiki-to-raw path not found: {raw_full}"
+
+    def test_all_wiki_metadata_have_symbols(self):
+        for wiki_rel, meta in WIKI_METADATA.items():
+            assert meta.get("symbol"), f"Missing symbol for {wiki_rel}"
+            assert meta.get("sourceHints"), f"Missing sourceHints for {wiki_rel}"
+
+    def test_all_wiki_metadata_have_source_path_in_wiki_to_raw(self):
+        for wiki_rel in WIKI_METADATA:
+            # Items under wiki/entities/ or wiki/concepts/ or wiki/synthesis/
+            short = wiki_rel.removeprefix("wiki/")
+            assert (
+                short in WIKI_TO_RAW or wiki_rel == "wiki/provenance_report.md"
+            ), f"Missing WIKI_TO_RAW mapping for {short}"


### PR DESCRIPTION
## Summary

Implements the OpenQC v1 traceability report pipeline (schemaVersion: `openqc.lsp.traceability.v1`) for ORCA-LSP.

## Changes

### New files
- **`scripts/generate_traceability_report.py`** — Standalone report generator that:
  - Scans `src/orca_lsp/` for docstrings and matches them to wiki pages via content hints
  - Maps `wiki/` pages to `raw/assets/` through a curated `WIKI_TO_RAW` table
  - Maps legacy diagnostic codes (`ORCA-E001`, `TC-W001`, etc.) to OpenQC format (`ORCA-INPUT-SYNTAX-001`, `TC-INPUT-TYPE-001`, etc.)
  - Generates GitHub source URLs for all raw assets
  - Produces a raw manifest with ok/boolean status
  - Supports `--check`, `--validate`, and `--output` flags

- **`tests/test_traceability_report.py`** — 62 tests covering:
  - Top-level schema fields (`schemaVersion`, `serverId`, `repository`, `languageId`)
  - `docstrings[]` contract (non-empty, repo-relative paths, matching wiki pages exist)
  - `wikiSources[]` contract (wikiPath, rawPath, sourceUrl integrity)
  - `ruleIds[]` contract (`<BACKEND>-<FILE_ROLE>-<CATEGORY>-NNN` format)
  - `sourceUrls[]` contract (rawPath, url consistency)
  - `rawManifest` contract (keys, boolean values, consistency with sourceUrls)
  - Validation failure modes (missing fields, wrong types, bad formats)
  - Write round-trip integrity
  - Wiki metadata completeness

- **`reports/docstring-wiki-raw-traceability.json`** — Initial generated report with:
  - 69 docstring-to-wiki mappings
  - 11 wiki-to-raw source links
  - 26 rule IDs (mapped from 26 legacy codes)
  - 25 source URLs (all raw assets)
  - 25-entry raw manifest (all ok)

### Modified files
- **`.gitignore\** — Added `uv.lock` and `.venv/` (build artifact exclusions)

## Test Plan

1. Run `python3 scripts/generate_traceability_report.py --check` — generates and validates the report, exits 0
2. Run `python3 -m pytest tests/test_traceability_report.py -v` — 62 tests pass
3. Run `make test` — all 854 tests pass
4. Run `make check` — lint, typecheck, and tests all pass
5. Verify report at `reports/docstring-wiki-raw-traceability.json`

Closes #100