### PR TITLE
Harden native GitHub Release finalization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,18 @@ jobs:
 
   github-release:
     name: Create GitHub release
-    needs: publish
+    needs: smoke-wheel
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+      - name: Verify checkout matches the pushed tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test "$(git rev-parse "$GITHUB_REF_NAME^{}")" = "$GITHUB_SHA"
       - uses: actions/download-artifact@v4
         with:
           name: python-distributions
@@ -73,4 +80,12 @@ jobs:
       - name: Attach distributions to the tagged release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "$GITHUB_REF_NAME" dist/* --verify-tag --generate-notes
+          GH_REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "::notice::GitHub Release $GITHUB_REF_NAME already exists; not creating a duplicate"
+            exit 0
+          fi
+          gh release create "$GITHUB_REF_NAME" dist/* --verify-tag --generate-notes

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ the wheel into a new virtual environment. The isolated smoke verifies
 invalid, and runtime-log fixtures before the OIDC-enabled `pypi` environment can
 publish. No long-lived PyPI token is used.
 
+GitHub Release finalization runs independently after the verified wheel smoke
+and attaches that exact build artifact. A PyPI outage or trusted-publisher
+misconfiguration can therefore fail PyPI without suppressing the native GitHub
+Release; the finalizer also proves that the checkout and tag equal
+`GITHUB_SHA` before creating the release.
+
 Maintainers can exercise the same artifact smoke before creating a tag:
 
 ```bash

--- a/tests/test_release_contract.py
+++ b/tests/test_release_contract.py
@@ -50,6 +50,17 @@ def test_release_workflow_is_tag_only_oidc_and_smokes_the_fresh_wheel() -> None:
     assert "python scripts/verify_release.py" in workflow
     assert "python scripts/smoke_test_wheel.py" in workflow
     assert "needs: smoke-wheel" in workflow
+    github_release = workflow.split("  github-release:", 1)[1]
+    assert "needs: smoke-wheel" in github_release
+    assert "needs: publish" not in github_release
+    assert "Verify checkout matches the pushed tag" in github_release
+    assert 'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"' in github_release
+    assert 'test "$(git rev-parse "$GITHUB_REF_NAME^{}")" = "$GITHUB_SHA"' in github_release
+    assert "actions/download-artifact@v4" in github_release
+    assert "name: python-distributions" in github_release
+    assert "GH_REPO: ${{ github.repository }}" in github_release
+    assert 'gh release view "$GITHUB_REF_NAME"' in github_release
+    assert "gh release create" in github_release
 
 
 def test_release_verifier_accepts_only_the_matching_release_tag() -> None:


### PR DESCRIPTION
## Summary
- finalize the native GitHub Release from the exact verified build artifact independently of PyPI
- verify checkout and tag both resolve to GITHUB_SHA before finalization
- avoid duplicate GitHub Release creation on a rerun
- document the channel split and cover it with workflow contract tests
- do not retag or republish the current version

## Tests
- make format
- make lint
- make typecheck
- make test
- make check
- release workflow YAML parse

Fixes #107